### PR TITLE
docs(technical-setup.md): fix rebrand install guide name

### DIFF
--- a/docs/contributing/technical-setup.md
+++ b/docs/contributing/technical-setup.md
@@ -2,7 +2,7 @@
 
 To ensure you have a successful experience working with our Developer Tutorials content, Ignite recommends this technical setup.
 
-## Setting Up Visual Studio Code
+## Setting up Visual Studio Code
 
 1. Install [Visual Studio Code](https://vscode-docs.readthedocs.io/en/latest/editor/setup/).
 1. Click **Extensions** in the sidebar.
@@ -58,4 +58,4 @@ The Z shell, also known as zsh, is a UNIX shell that is built on top of the macO
 
 ## Install Go
 
-Follow the steps in [Install Starport](../guide/install.md) docs to install Starport and Go.
+Follow the steps in [Install Ignite CLI](../guide/install.md) docs to install Ignite CLI and Go.

--- a/docs/migration/v0.19.2.md
+++ b/docs/migration/v0.19.2.md
@@ -16,8 +16,8 @@ With Ignite CLI v0.19.2, the contents of the deprecated Ignite CLI Modules `tend
 To migrate your chain that was scaffolded with Ignite CLI versions lower than v0.19.2: 
 
 1. IBC upgrade: Use the [IBC migration documents](https://github.com/cosmos/ibc-go/blob/main/docs/migrations/v1-to-v2.md)
-   
-2. In your chain's `go.mod` file, remove `tendermint/spm` and add the v0.19.2 version of `tendermint/starport`. If your chain uses these packages, change the import paths as shown: 
+
+2. In your chain's `go.mod` file, remove `tendermint/spm` and add the v0.19.2 version of `tendermint/starport`. If your chain uses these packages, change the import paths as shown:
 
     - `github.com/tendermint/spm/ibckeeper` moved to `github.com/tendermint/starport/starport/pkg/cosmosibckeeper`
     - `github.com/tendermint/spm/cosmoscmd` moved to `github.com/tendermint/starport/starport/pkg/cosmoscmd` 


### PR DESCRIPTION
migration paths for the GitHub packages still need updating, we can do next round 