### PR TITLE
docs: fix typos on the Developer Tutorials

### DIFF
--- a/docs/guide/blog/comment-blog.md
+++ b/docs/guide/blog/comment-blog.md
@@ -163,6 +163,11 @@ func (k msgServer) CreateComment(goCtx context.Context, msg *types.MsgCreateComm
 
 	post := k.GetPost(ctx, msg.PostID)
 	postId := post.Id
+	
+	// Check if the Post Exists for which a comment is being created
+	if msg.PostID == 0 {
+		return nil, sdkerrors.Wrapf(types.ErrID, "Post Blog Id does not exist for which comment with Blog Id %d was made", msg.PostID)
+	}
 
 	// Create variable of type comment
 	var comment = types.Comment{
@@ -173,12 +178,7 @@ func (k msgServer) CreateComment(goCtx context.Context, msg *types.MsgCreateComm
 		PostID:    msg.PostID,
 		CreatedAt: ctx.BlockHeight(),
 	}
-
-	// Check if the Post Exists for which a comment is being created
-	if msg.PostID != postId {
-		return nil, sdkerrors.Wrapf(types.ErrID, "Post Blog Id does not exist for which comment with Blog Id %d was made", msg.PostID)
-	}
-
+	
 	// Check if the comment is older than the Post. If more than 100 blocks, then return error.
 	if comment.CreatedAt > post.CreatedAt+100 {
 		return nil, sdkerrors.Wrapf(types.ErrCommentOld, "Comment created at %d is older than post created at %d", comment.CreatedAt, post.CreatedAt)

--- a/docs/guide/blog/comment-blog.md
+++ b/docs/guide/blog/comment-blog.md
@@ -175,7 +175,7 @@ func (k msgServer) CreateComment(goCtx context.Context, msg *types.MsgCreateComm
 	}
 
 	// Check if the Post Exists for which a comment is being created
-	if msg.PostID > postId && msg.PostID == postId {
+	if msg.PostID != postId {
 		return nil, sdkerrors.Wrapf(types.ErrID, "Post Blog Id does not exist for which comment with Blog Id %d was made", msg.PostID)
 	}
 

--- a/docs/guide/ibc.md
+++ b/docs/guide/ibc.md
@@ -75,26 +75,26 @@ A new directory with the code for an IBC module is created in `planet/x/blog`. M
 
 Next, create the CRUD actions for the blog module types.
 
-Use the `ignite type` command to scaffold the boilerplate code for the create, read, update, and delete (CRUD) actions.
+Use the `ignite list` command to scaffold the boilerplate code for the create, read, update, and delete (CRUD) actions.
 
-These `ignite type` commands create CRUD code for the following transactions:
+These `ignite list` commands create CRUD code for the following transactions:
 
 - Creating blog posts
 
   ```go
-  ignite scaffold list post title content --module blog
+  ignite scaffold list post title content --no-message --module blog
   ```
 
 - Processing acknowledgments for sent posts
 
   ```go
-  ignite scaffold list sentPost postID title chain --module blog
+  ignite scaffold list sentPost postID title chain --no-message --module blog
   ```
 
 - Managing post timeouts
 
   ```go
-  ignite scaffold list timedoutPost title chain --module blog
+  ignite scaffold list timedoutPost title chain --no-message --module blog
   ```
 
 The scaffolded code includes proto files for defining data structures, messages, messages handlers, keepers for modifying the state, and CLI commands.
@@ -105,7 +105,7 @@ The scaffolded code includes proto files for defining data structures, messages,
 ignite scaffold list [typeName] [field1] [field2] ... [flags]
 ```
 
-The first argument of the `ignite type [typeName]` command specifies the name of the type being created. For the blog app, you created `post`, `sentPost`, and `timedoutPost` types.
+The first argument of the `ignite list [typeName]` command specifies the name of the type being created. For the blog app, you created `post`, `sentPost`, and `timedoutPost` types.
 
 The next arguments define the fields that are associated with the type. For the blog app, you created `title`, `content`, `postID`, and `chain` fields.
 

--- a/docs/guide/ibc.md
+++ b/docs/guide/ibc.md
@@ -75,9 +75,9 @@ A new directory with the code for an IBC module is created in `planet/x/blog`. M
 
 Next, create the CRUD actions for the blog module types.
 
-Use the `ignite list` command to scaffold the boilerplate code for the create, read, update, and delete (CRUD) actions.
+Use the `ignite scaffold list` command to scaffold the boilerplate code for the create, read, update, and delete (CRUD) actions.
 
-These `ignite list` commands create CRUD code for the following transactions:
+These `ignite scaffold list` commands create CRUD code for the following transactions:
 
 - Creating blog posts
 
@@ -105,7 +105,7 @@ The scaffolded code includes proto files for defining data structures, messages,
 ignite scaffold list [typeName] [field1] [field2] ... [flags]
 ```
 
-The first argument of the `ignite list [typeName]` command specifies the name of the type being created. For the blog app, you created `post`, `sentPost`, and `timedoutPost` types.
+The first argument of the `ignite scaffold list [typeName]` command specifies the name of the type being created. For the blog app, you created `post`, `sentPost`, and `timedoutPost` types.
 
 The next arguments define the fields that are associated with the type. For the blog app, you created `title`, `content`, `postID`, and `chain` fields.
 


### PR DESCRIPTION
close #2292 

## Description

Fixed typos on the Developer Tutorials: blog, ibc

Details are described in the issue