### PR TITLE
Added tendermint subcommand before unsafe-reset-all.

### DIFF
--- a/ignite/pkg/chaincmd/chaincmd.go
+++ b/ignite/pkg/chaincmd/chaincmd.go
@@ -19,7 +19,7 @@ const (
 	commandStatus            = "status"
 	commandTx                = "tx"
 	commandQuery             = "query"
-	commandUnsafeReset       = "unsafe-reset-all"
+	commandUnsafeReset       = "tendermint unsafe-reset-all"
 	commandExport            = "export"
 
 	optionHome                             = "--home"


### PR DESCRIPTION
Not sure how this one slipped through but it breaks the hot reload. Hopefully this will be quickly merged into the mainline.

this is caused by upstream cosmos-sdk change https://github.com/cosmos/cosmos-sdk/pull/11562