### PR TITLE
fix(templates): use latest version to fix Linux ARM support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [`v0.20.3`](https://github.com/ignite-hq/cli/releases/tag/v0.20.3)
+
+### Fixes
+
+- Use latest version of CLI in templates to fix Linux ARM support _(It's now possible to develop chains in Linux ARM machines and since the chain depends on the CLI in its go.mod, it needs to use the latest version that support ARM targets)_
+
+## [`v0.20.2`](https://github.com/ignite-hq/cli/releases/tag/v0.20.2)
+
+### Fixes
+
+- Use `unsafe-reset-all` cmd under `tendermint` cmd for chains that use `=> v0.45.3` version of Cosmos SDK
+
 ## [`v0.20.1`](https://github.com/ignite-hq/cli/releases/tag/v0.20.1)
 
 ### Features

--- a/ignite/templates/app/stargate/go.mod.plush
+++ b/ignite/templates/app/stargate/go.mod.plush
@@ -13,7 +13,7 @@ require (
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.0
     github.com/tendermint/spn v0.1.1-0.20220407154406-5cfd1bf28150
-	github.com/ignite-hq/cli v0.20.0
+	github.com/ignite-hq/cli v0.20.3
     github.com/tendermint/tendermint v0.34.16
     github.com/tendermint/tm-db v0.6.6
     google.golang.org/genproto v0.0.0-20220317150908-0efb43f6373e


### PR DESCRIPTION
It's now possible to develop chains in Linux ARM machines and since
the chain depends on the CLI in its go.mod, it needs to use use the latest version
that support ARM targets.