### PR TITLE
fix(network): fix wrong account address check for the join command

### DIFF
--- a/ignite/services/network/join.go
+++ b/ignite/services/network/join.go
@@ -125,10 +125,9 @@ func (n Network) sendAccountRequest(
 	genesisPath string,
 	isCustomGentx bool,
 	launchID uint64,
-	accountAddress string,
+	address string,
 	amount sdk.Coins,
 ) (err error) {
-	address := n.account.Address(networktypes.SPN)
 	n.ev.Send(events.New(events.StatusOngoing, "Verifying account already exists "+address))
 
 	// if is custom gentx path, avoid to check account into genesis from the home folder
@@ -154,7 +153,7 @@ func (n Network) sendAccountRequest(
 	msg := launchtypes.NewMsgRequestAddAccount(
 		n.account.Address(networktypes.SPN),
 		launchID,
-		accountAddress,
+		address,
 		amount,
 	)
 


### PR DESCRIPTION
# Description

we are checking if the wrong address exists before adding