### PR TITLE
feat(network/publish): add support for source URLs without protocol

### DIFF
--- a/ignite/cmd/network_chain_publish.go
+++ b/ignite/cmd/network_chain_publish.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tendermint/spn/pkg/chainid"
 
 	"github.com/ignite-hq/cli/ignite/pkg/clispinner"
+	"github.com/ignite-hq/cli/ignite/pkg/xurl"
 	"github.com/ignite-hq/cli/ignite/services/network"
 	"github.com/ignite-hq/cli/ignite/services/network/networkchain"
 )
@@ -58,7 +59,7 @@ func NewNetworkChainPublish() *cobra.Command {
 
 func networkChainPublishHandler(cmd *cobra.Command, args []string) error {
 	var (
-		source                    = args[0]
+		source                    = xurl.HTTPS(args[0])
 		tag, _                    = cmd.Flags().GetString(flagTag)
 		branch, _                 = cmd.Flags().GetString(flagBranch)
 		hash, _                   = cmd.Flags().GetString(flagHash)

--- a/ignite/pkg/xurl/xurl.go
+++ b/ignite/pkg/xurl/xurl.go
@@ -22,6 +22,14 @@ func HTTP(s string) string {
 	return "http://" + Address(s)
 }
 
+// HTTPS unsures that s url contains HTTPS protocol identifier.
+func HTTPS(s string) string {
+	if strings.HasPrefix(s, "https") {
+		return s
+	}
+	return "https://" + Address(s)
+}
+
 // WS unsures that s url contains WS protocol identifier.
 func WS(s string) string {
 	if strings.HasPrefix(s, "ws") {

--- a/ignite/pkg/xurl/xurl_test.go
+++ b/ignite/pkg/xurl/xurl_test.go
@@ -1,14 +1,12 @@
 package xurl
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestHTTPEnsurePort(t *testing.T) {
-	fmt.Println(HTTPEnsurePort("https://26657-crimson-pheasant-2x3fbpak.ws-eu03.gitpod.io/"))
 	cases := []struct {
 		addr    string
 		ensured string
@@ -21,6 +19,35 @@ func TestHTTPEnsurePort(t *testing.T) {
 		t.Run(tt.addr, func(t *testing.T) {
 			addr := HTTPEnsurePort(tt.addr)
 			require.Equal(t, tt.ensured, addr)
+		})
+	}
+}
+
+func TestHTTPS(t *testing.T) {
+	cases := []struct {
+		name string
+		addr string
+		want string
+	}{
+		{
+			name: "with scheme",
+			addr: "https://github.com/ignite-hq/cli",
+			want: "https://github.com/ignite-hq/cli",
+		},
+		{
+			name: "without scheme",
+			addr: "github.com/ignite-hq/cli",
+			want: "https://github.com/ignite-hq/cli",
+		},
+		{
+			name: "empty",
+			addr: "",
+			want: "https://",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, HTTPS(tt.addr))
 		})
 	}
 }


### PR DESCRIPTION
resolves #2380

The changes in the PR ensure that the source URL argument in the `ignite network chain publish` command is always prefixed with the "https://" prefix.