### PR TITLE
refactor(pkg/xurl): change protocol functions to prevent possible bugs

### DIFF
--- a/ignite/cmd/network_chain_publish.go
+++ b/ignite/cmd/network_chain_publish.go
@@ -73,7 +73,7 @@ func networkChainPublishHandler(cmd *cobra.Command, args []string) error {
 		rewardDuration, _         = cmd.Flags().GetInt64(flagRewardHeight)
 	)
 
-	source, err := xurl.HTTPS(args[0])
+	source, err := xurl.MightHTTPS(args[0])
 	if err != nil {
 		return fmt.Errorf("invalid source url format: %w", err)
 	}

--- a/ignite/cmd/network_chain_publish.go
+++ b/ignite/cmd/network_chain_publish.go
@@ -59,7 +59,6 @@ func NewNetworkChainPublish() *cobra.Command {
 
 func networkChainPublishHandler(cmd *cobra.Command, args []string) error {
 	var (
-		source                    = xurl.HTTPS(args[0])
 		tag, _                    = cmd.Flags().GetString(flagTag)
 		branch, _                 = cmd.Flags().GetString(flagBranch)
 		hash, _                   = cmd.Flags().GetString(flagHash)
@@ -73,6 +72,11 @@ func networkChainPublishHandler(cmd *cobra.Command, args []string) error {
 		rewardCoinsStr, _         = cmd.Flags().GetString(flagRewardCoins)
 		rewardDuration, _         = cmd.Flags().GetInt64(flagRewardHeight)
 	)
+
+	source, err := xurl.HTTPS(args[0])
+	if err != nil {
+		return fmt.Errorf("invalid source url format: %w", err)
+	}
 
 	if campaign != 0 && campaignTotalSupplyStr != "" {
 		return fmt.Errorf("%s and %s flags cannot be set together", flagCampaign, flagCampaignTotalSupply)

--- a/ignite/pkg/xurl/xurl.go
+++ b/ignite/pkg/xurl/xurl.go
@@ -1,41 +1,62 @@
 package xurl
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
 )
 
 // TCP unsures that s url contains TCP protocol identifier.
-func TCP(s string) string {
-	if strings.HasPrefix(s, "tcp") {
-		return s
+func TCP(s string) (string, error) {
+	u, err := parseURL(s)
+	if err != nil {
+		return "", err
 	}
-	return "tcp://" + Address(s)
+
+	if u.Scheme != "tcp" {
+		u.Scheme = "tcp"
+	}
+	return u.String(), nil
 }
 
 // HTTP unsures that s url contains HTTP protocol identifier.
-func HTTP(s string) string {
-	if strings.HasPrefix(s, "http") {
-		return s
+func HTTP(s string) (string, error) {
+	u, err := parseURL(s)
+	if err != nil {
+		return "", err
 	}
-	return "http://" + Address(s)
+
+	if u.Scheme != "http" {
+		u.Scheme = "http"
+	}
+	return u.String(), nil
 }
 
 // HTTPS unsures that s url contains HTTPS protocol identifier.
-func HTTPS(s string) string {
-	if strings.HasPrefix(s, "https") {
-		return s
+func HTTPS(s string) (string, error) {
+	u, err := parseURL(s)
+	if err != nil {
+		return "", err
 	}
-	return "https://" + Address(s)
+
+	if u.Scheme != "https" {
+		u.Scheme = "https"
+	}
+	return u.String(), nil
 }
 
 // WS unsures that s url contains WS protocol identifier.
-func WS(s string) string {
-	if strings.HasPrefix(s, "ws") {
-		return s
+func WS(s string) (string, error) {
+	u, err := parseURL(s)
+	if err != nil {
+		return "", err
 	}
-	return "ws://" + Address(s)
+
+	if u.Scheme != "ws" {
+		u.Scheme = "ws"
+	}
+	return u.String(), nil
 }
 
 // HTTPEnsurePort ensures that url has a port number suits with the connection type.
@@ -92,4 +113,12 @@ func IsLocalPath(address string) bool {
 
 func IsHTTP(address string) bool {
 	return strings.HasPrefix(address, "http")
+}
+
+func parseURL(s string) (*url.URL, error) {
+	if s == "" {
+		return nil, errors.New("url is empty")
+	}
+
+	return url.Parse(Address(s))
 }

--- a/ignite/pkg/xurl/xurl.go
+++ b/ignite/pkg/xurl/xurl.go
@@ -7,6 +7,13 @@ import (
 	"strings"
 )
 
+const (
+	schemeTCP = "tcp"
+	schemeHTTP = "http"
+	schemeHTTPS = "https"
+	schemeWS = "ws"
+)
+
 // TCP unsures that s url contains TCP protocol identifier.
 func TCP(s string) (string, error) {
 	u, err := parseURL(s)
@@ -14,8 +21,8 @@ func TCP(s string) (string, error) {
 		return "", err
 	}
 
-	if u.Scheme != "tcp" {
-		u.Scheme = "tcp"
+	if u.Scheme != schemeTCP {
+		u.Scheme = schemeTCP
 	}
 	return u.String(), nil
 }
@@ -27,8 +34,8 @@ func HTTP(s string) (string, error) {
 		return "", err
 	}
 
-	if u.Scheme != "http" {
-		u.Scheme = "http"
+	if u.Scheme != schemeHTTP {
+		u.Scheme = schemeHTTP
 	}
 	return u.String(), nil
 }
@@ -40,8 +47,8 @@ func HTTPS(s string) (string, error) {
 		return "", err
 	}
 
-	if u.Scheme != "https" {
-		u.Scheme = "https"
+	if u.Scheme != schemeHTTPS {
+		u.Scheme = schemeHTTPS
 	}
 	return u.String(), nil
 }
@@ -53,8 +60,8 @@ func WS(s string) (string, error) {
 		return "", err
 	}
 
-	if u.Scheme != "ws" {
-		u.Scheme = "ws"
+	if u.Scheme != schemeWS {
+		u.Scheme = schemeWS
 	}
 	return u.String(), nil
 }
@@ -68,7 +75,7 @@ func HTTPEnsurePort(s string) string {
 
 	port := "80"
 
-	if u.Scheme == "https" {
+	if u.Scheme == schemeHTTPS {
 		port = "443"
 	}
 

--- a/ignite/pkg/xurl/xurl.go
+++ b/ignite/pkg/xurl/xurl.go
@@ -8,10 +8,10 @@ import (
 )
 
 const (
-	schemeTCP = "tcp"
-	schemeHTTP = "http"
+	schemeTCP   = "tcp"
+	schemeHTTP  = "http"
 	schemeHTTPS = "https"
-	schemeWS = "ws"
+	schemeWS    = "ws"
 )
 
 // TCP unsures that s url contains TCP protocol identifier.

--- a/ignite/pkg/xurl/xurl.go
+++ b/ignite/pkg/xurl/xurl.go
@@ -15,7 +15,7 @@ const (
 	schemeWS    = "ws"
 )
 
-// TCP unsures that a URL contains a TCP protocol identifier.
+// TCP ensures that a URL contains a TCP scheme.
 func TCP(s string) (string, error) {
 	u, err := parseURL(s)
 	if err != nil {
@@ -27,7 +27,7 @@ func TCP(s string) (string, error) {
 	return u.String(), nil
 }
 
-// HTTP unsures that a URL contains an HTTP protocol identifier.
+// HTTP ensures that a URL contains an HTTP scheme.
 func HTTP(s string) (string, error) {
 	u, err := parseURL(s)
 	if err != nil {
@@ -39,7 +39,7 @@ func HTTP(s string) (string, error) {
 	return u.String(), nil
 }
 
-// HTTPS unsures that a URL contains an HTTPS protocol identifier.
+// HTTPS ensures that a URL contains an HTTPS scheme.
 func HTTPS(s string) (string, error) {
 	u, err := parseURL(s)
 	if err != nil {
@@ -51,7 +51,17 @@ func HTTPS(s string) (string, error) {
 	return u.String(), nil
 }
 
-// WS unsures that a URL contains a WS protocol identifier.
+// MightHTTPS ensures that a URL contains an HTTPS scheme when the current scheme is not HTTP.
+// When the URL contains an HTTP scheme it is not modified.
+func MightHTTPS(s string) (string, error) {
+	if strings.HasPrefix(strings.ToLower(s), "http://") {
+		return s, nil
+	}
+
+	return HTTPS(s)
+}
+
+// WS ensures that a URL contains a WS scheme.
 func WS(s string) (string, error) {
 	u, err := parseURL(s)
 	if err != nil {
@@ -93,7 +103,7 @@ func CleanPath(s string) string {
 	return u.String()
 }
 
-// Address unsures that address contains localhost as host if non specified.
+// Address ensures that address contains localhost as host if non specified.
 func Address(address string) string {
 	if strings.HasPrefix(address, ":") {
 		return "localhost" + address

--- a/ignite/pkg/xurl/xurl.go
+++ b/ignite/pkg/xurl/xurl.go
@@ -22,9 +22,8 @@ func TCP(s string) (string, error) {
 		return "", err
 	}
 
-	if u.Scheme != schemeTCP {
-		u.Scheme = schemeTCP
-	}
+	u.Scheme = schemeTCP
+
 	return u.String(), nil
 }
 
@@ -35,9 +34,8 @@ func HTTP(s string) (string, error) {
 		return "", err
 	}
 
-	if u.Scheme != schemeHTTP {
-		u.Scheme = schemeHTTP
-	}
+	u.Scheme = schemeHTTP
+
 	return u.String(), nil
 }
 
@@ -48,9 +46,8 @@ func HTTPS(s string) (string, error) {
 		return "", err
 	}
 
-	if u.Scheme != schemeHTTPS {
-		u.Scheme = schemeHTTPS
-	}
+	u.Scheme = schemeHTTPS
+
 	return u.String(), nil
 }
 
@@ -61,9 +58,8 @@ func WS(s string) (string, error) {
 		return "", err
 	}
 
-	if u.Scheme != schemeWS {
-		u.Scheme = schemeWS
-	}
+	u.Scheme = schemeWS
+
 	return u.String(), nil
 }
 
@@ -129,7 +125,9 @@ func parseURL(s string) (*url.URL, error) {
 	}
 
 	// Handle the case where the URI is an IP:PORT or HOST:PORT
-	// without scheme prefix because that case can't be URL parsed
+	// without scheme prefix because that case can't be URL parsed.
+	// When the URI has not scheme it is parsed as a path by "url.Parse"
+	// placing the colon within the path, which is invalid.
 	if isAddressPort(s) {
 		return &url.URL{Host: s}, nil
 	}

--- a/ignite/pkg/xurl/xurl.go
+++ b/ignite/pkg/xurl/xurl.go
@@ -3,6 +3,7 @@ package xurl
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"strings"
 )
@@ -14,7 +15,7 @@ const (
 	schemeWS    = "ws"
 )
 
-// TCP unsures that s url contains TCP protocol identifier.
+// TCP unsures that a URL contains a TCP protocol identifier.
 func TCP(s string) (string, error) {
 	u, err := parseURL(s)
 	if err != nil {
@@ -27,7 +28,7 @@ func TCP(s string) (string, error) {
 	return u.String(), nil
 }
 
-// HTTP unsures that s url contains HTTP protocol identifier.
+// HTTP unsures that a URL contains an HTTP protocol identifier.
 func HTTP(s string) (string, error) {
 	u, err := parseURL(s)
 	if err != nil {
@@ -40,7 +41,7 @@ func HTTP(s string) (string, error) {
 	return u.String(), nil
 }
 
-// HTTPS unsures that s url contains HTTPS protocol identifier.
+// HTTPS unsures that a URL contains an HTTPS protocol identifier.
 func HTTPS(s string) (string, error) {
 	u, err := parseURL(s)
 	if err != nil {
@@ -53,7 +54,7 @@ func HTTPS(s string) (string, error) {
 	return u.String(), nil
 }
 
-// WS unsures that s url contains WS protocol identifier.
+// WS unsures that a URL contains a WS protocol identifier.
 func WS(s string) (string, error) {
 	u, err := parseURL(s)
 	if err != nil {
@@ -127,5 +128,24 @@ func parseURL(s string) (*url.URL, error) {
 		return nil, errors.New("url is empty")
 	}
 
+	// Handle the case where the URI is an IP:PORT or HOST:PORT
+	// without scheme prefix because that case can't be URL parsed
+	if isAddressPort(s) {
+		return &url.URL{Host: s}, nil
+	}
+
 	return url.Parse(Address(s))
+}
+
+func isAddressPort(s string) bool {
+	// Check that the value doesn't contain a URI path
+	if strings.Index(s, "/") != -1 {
+		return false
+	}
+
+	// Use the net split function to support IPv6 addresses
+	if _, _, err := net.SplitHostPort(s); err != nil {
+		return false
+	}
+	return true
 }

--- a/ignite/pkg/xurl/xurl_test.go
+++ b/ignite/pkg/xurl/xurl_test.go
@@ -264,3 +264,65 @@ func TestWS(t *testing.T) {
 		})
 	}
 }
+
+func TestMightHTTPS(t *testing.T) {
+	cases := []struct {
+		name  string
+		addr  string
+		want  string
+		error bool
+	}{
+		{
+			name: "with http scheme",
+			addr: "http://github.com/ignite-hq/cli",
+			want: "http://github.com/ignite-hq/cli",
+		},
+		{
+			name: "with https scheme",
+			addr: "https://github.com/ignite-hq/cli",
+			want: "https://github.com/ignite-hq/cli",
+		},
+		{
+			name: "without scheme",
+			addr: "github.com/ignite-hq/cli",
+			want: "https://github.com/ignite-hq/cli",
+		},
+		{
+			name: "with invalid scheme",
+			addr: "ftp://github.com/ignite-hq/cli",
+			want: "https://github.com/ignite-hq/cli",
+		},
+		{
+			name: "with ip and port",
+			addr: "0.0.0.0:4500",
+			want: "https://0.0.0.0:4500",
+		},
+		{
+			name: "with localhost and port",
+			addr: "localhost:4500",
+			want: "https://localhost:4500",
+		},
+		{
+			name:  "with invalid url",
+			addr:  "https://github.com:x",
+			error: true,
+		},
+		{
+			name:  "empty",
+			addr:  "",
+			error: true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			addr, err := MightHTTPS(tt.addr)
+			if tt.error {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, addr)
+			}
+		})
+	}
+}

--- a/ignite/pkg/xurl/xurl_test.go
+++ b/ignite/pkg/xurl/xurl_test.go
@@ -23,11 +23,106 @@ func TestHTTPEnsurePort(t *testing.T) {
 	}
 }
 
+func TestTCP(t *testing.T) {
+	cases := []struct {
+		name  string
+		addr  string
+		want  string
+		error bool
+	}{
+		{
+			name: "with scheme",
+			addr: "tcp://github.com/ignite-hq/cli",
+			want: "tcp://github.com/ignite-hq/cli",
+		},
+		{
+			name: "without scheme",
+			addr: "github.com/ignite-hq/cli",
+			want: "tcp://github.com/ignite-hq/cli",
+		},
+		{
+			name: "with invalid scheme",
+			addr: "ftp://github.com/ignite-hq/cli",
+			want: "tcp://github.com/ignite-hq/cli",
+		},
+		{
+			name:  "with invalid url",
+			addr:  "tcp://github.com:x",
+			error: true,
+		},
+		{
+			name:  "empty",
+			addr:  "",
+			error: true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			addr, err := TCP(tt.addr)
+			if tt.error {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, addr)
+			}
+		})
+	}
+}
+
+func TestHTTP(t *testing.T) {
+	cases := []struct {
+		name  string
+		addr  string
+		want  string
+		error bool
+	}{
+		{
+			name: "with scheme",
+			addr: "http://github.com/ignite-hq/cli",
+			want: "http://github.com/ignite-hq/cli",
+		},
+		{
+			name: "without scheme",
+			addr: "github.com/ignite-hq/cli",
+			want: "http://github.com/ignite-hq/cli",
+		},
+		{
+			name: "with invalid scheme",
+			addr: "ftp://github.com/ignite-hq/cli",
+			want: "http://github.com/ignite-hq/cli",
+		},
+		{
+			name:  "with invalid url",
+			addr:  "http://github.com:x",
+			error: true,
+		},
+		{
+			name:  "empty",
+			addr:  "",
+			error: true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			addr, err := HTTP(tt.addr)
+			if tt.error {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, addr)
+			}
+		})
+	}
+}
+
 func TestHTTPS(t *testing.T) {
 	cases := []struct {
-		name string
-		addr string
-		want string
+		name  string
+		addr  string
+		want  string
+		error bool
 	}{
 		{
 			name: "with scheme",
@@ -40,14 +135,78 @@ func TestHTTPS(t *testing.T) {
 			want: "https://github.com/ignite-hq/cli",
 		},
 		{
-			name: "empty",
-			addr: "",
-			want: "https://",
+			name: "with invalid scheme",
+			addr: "ftp://github.com/ignite-hq/cli",
+			want: "https://github.com/ignite-hq/cli",
+		},
+		{
+			name:  "with invalid url",
+			addr:  "https://github.com:x",
+			error: true,
+		},
+		{
+			name:  "empty",
+			addr:  "",
+			error: true,
 		},
 	}
+
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, HTTPS(tt.addr))
+			addr, err := HTTPS(tt.addr)
+			if tt.error {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, addr)
+			}
+		})
+	}
+}
+
+func TestWS(t *testing.T) {
+	cases := []struct {
+		name  string
+		addr  string
+		want  string
+		error bool
+	}{
+		{
+			name: "with scheme",
+			addr: "ws://github.com/ignite-hq/cli",
+			want: "ws://github.com/ignite-hq/cli",
+		},
+		{
+			name: "without scheme",
+			addr: "github.com/ignite-hq/cli",
+			want: "ws://github.com/ignite-hq/cli",
+		},
+		{
+			name: "with invalid scheme",
+			addr: "ftp://github.com/ignite-hq/cli",
+			want: "ws://github.com/ignite-hq/cli",
+		},
+		{
+			name:  "with invalid url",
+			addr:  "ws://github.com:x",
+			error: true,
+		},
+		{
+			name:  "empty",
+			addr:  "",
+			error: true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			addr, err := WS(tt.addr)
+			if tt.error {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, addr)
+			}
 		})
 	}
 }

--- a/ignite/pkg/xurl/xurl_test.go
+++ b/ignite/pkg/xurl/xurl_test.go
@@ -8,17 +8,31 @@ import (
 
 func TestHTTPEnsurePort(t *testing.T) {
 	cases := []struct {
-		addr    string
-		ensured string
+		name string
+		addr string
+		want string
 	}{
-		{"http://localhost", "http://localhost:80"},
-		{"https://localhost", "https://localhost:443"},
-		{"http://localhost:4000", "http://localhost:4000"},
+		{
+			name: "http",
+			addr: "http://localhost",
+			want: "http://localhost:80",
+		},
+		{
+			name: "https",
+			addr: "https://localhost",
+			want: "https://localhost:443",
+		},
+		{
+			name: "custom",
+			addr: "http://localhost:4000",
+			want: "http://localhost:4000",
+		},
 	}
+
 	for _, tt := range cases {
-		t.Run(tt.addr, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			addr := HTTPEnsurePort(tt.addr)
-			require.Equal(t, tt.ensured, addr)
+			require.Equal(t, tt.want, addr)
 		})
 	}
 }

--- a/ignite/pkg/xurl/xurl_test.go
+++ b/ignite/pkg/xurl/xurl_test.go
@@ -60,6 +60,16 @@ func TestTCP(t *testing.T) {
 			want: "tcp://github.com/ignite-hq/cli",
 		},
 		{
+			name: "with ip and port",
+			addr: "0.0.0.0:4500",
+			want: "tcp://0.0.0.0:4500",
+		},
+		{
+			name: "with localhost and port",
+			addr: "localhost:4500",
+			want: "tcp://localhost:4500",
+		},
+		{
 			name:  "with invalid url",
 			addr:  "tcp://github.com:x",
 			error: true,
@@ -105,6 +115,16 @@ func TestHTTP(t *testing.T) {
 			name: "with invalid scheme",
 			addr: "ftp://github.com/ignite-hq/cli",
 			want: "http://github.com/ignite-hq/cli",
+		},
+		{
+			name: "with ip and port",
+			addr: "0.0.0.0:4500",
+			want: "http://0.0.0.0:4500",
+		},
+		{
+			name: "with localhost and port",
+			addr: "localhost:4500",
+			want: "http://localhost:4500",
 		},
 		{
 			name:  "with invalid url",
@@ -154,6 +174,16 @@ func TestHTTPS(t *testing.T) {
 			want: "https://github.com/ignite-hq/cli",
 		},
 		{
+			name: "with ip and port",
+			addr: "0.0.0.0:4500",
+			want: "https://0.0.0.0:4500",
+		},
+		{
+			name: "with localhost and port",
+			addr: "localhost:4500",
+			want: "https://localhost:4500",
+		},
+		{
 			name:  "with invalid url",
 			addr:  "https://github.com:x",
 			error: true,
@@ -199,6 +229,16 @@ func TestWS(t *testing.T) {
 			name: "with invalid scheme",
 			addr: "ftp://github.com/ignite-hq/cli",
 			want: "ws://github.com/ignite-hq/cli",
+		},
+		{
+			name: "with ip and port",
+			addr: "0.0.0.0:4500",
+			want: "ws://0.0.0.0:4500",
+		},
+		{
+			name: "with localhost and port",
+			addr: "localhost:4500",
+			want: "ws://localhost:4500",
 		},
 		{
 			name:  "with invalid url",

--- a/ignite/services/chain/chain.go
+++ b/ignite/services/chain/chain.go
@@ -442,11 +442,16 @@ func (c *Chain) Commands(ctx context.Context) (chaincmdrunner.Runner, error) {
 		return chaincmdrunner.Runner{}, err
 	}
 
+	nodeAddr, err := xurl.TCP(config.Host.RPC)
+	if err != nil {
+		return chaincmdrunner.Runner{}, err
+	}
+
 	chainCommandOptions := []chaincmd.Option{
 		chaincmd.WithChainID(id),
 		chaincmd.WithHome(home),
 		chaincmd.WithVersion(c.Version),
-		chaincmd.WithNodeAddress(xurl.TCP(config.Host.RPC)),
+		chaincmd.WithNodeAddress(nodeAddr),
 		chaincmd.WithKeyringBackend(backend),
 	}
 

--- a/ignite/services/chain/faucet.go
+++ b/ignite/services/chain/faucet.go
@@ -62,10 +62,15 @@ func (c *Chain) Faucet(ctx context.Context) (cosmosfaucet.Faucet, error) {
 		apiAddress = envAPIAddress
 	}
 
+	apiAddress, err = xurl.HTTP(apiAddress)
+	if err != nil {
+		return cosmosfaucet.Faucet{}, fmt.Errorf("invalid host api address format: %w", err)
+	}
+
 	faucetOptions := []cosmosfaucet.Option{
 		cosmosfaucet.Account(*conf.Faucet.Name, "", ""),
 		cosmosfaucet.ChainID(id),
-		cosmosfaucet.OpenAPI(xurl.HTTP(apiAddress)),
+		cosmosfaucet.OpenAPI(apiAddress),
 	}
 
 	// parse coins to pass to the faucet as coins.

--- a/ignite/services/chain/serve.go
+++ b/ignite/services/chain/serve.go
@@ -409,13 +409,19 @@ func (c *Chain) start(ctx context.Context, config chainconfig.Config) error {
 
 	// set the app as being served
 	c.served = true
+	
+	// note: address format errors are handled by the
+	// error group, so they can be safely ignored here
+	rpcAddr, _ := xurl.HTTP(config.Host.RPC)
+	apiAddr, _ := xurl.HTTP(config.Host.API)
 
 	// print the server addresses.
-	fmt.Fprintf(c.stdLog().out, "🌍 Tendermint node: %s\n", xurl.HTTP(config.Host.RPC))
-	fmt.Fprintf(c.stdLog().out, "🌍 Blockchain API: %s\n", xurl.HTTP(config.Host.API))
+	fmt.Fprintf(c.stdLog().out, "🌍 Tendermint node: %s\n", rpcAddr)
+	fmt.Fprintf(c.stdLog().out, "🌍 Blockchain API: %s\n", apiAddr)
 
 	if isFaucetEnabled {
-		fmt.Fprintf(c.stdLog().out, "🌍 Token faucet: %s\n", xurl.HTTP(chainconfig.FaucetHost(config)))
+		faucetAddr, _ := xurl.HTTP(chainconfig.FaucetHost(config))
+		fmt.Fprintf(c.stdLog().out, "🌍 Token faucet: %s\n", faucetAddr)
 	}
 
 	return g.Wait()

--- a/ignite/services/chain/serve.go
+++ b/ignite/services/chain/serve.go
@@ -409,7 +409,7 @@ func (c *Chain) start(ctx context.Context, config chainconfig.Config) error {
 
 	// set the app as being served
 	c.served = true
-	
+
 	// note: address format errors are handled by the
 	// error group, so they can be safely ignored here
 	rpcAddr, _ := xurl.HTTP(config.Host.RPC)

--- a/ignite/services/network/networkchain/simulate.go
+++ b/ignite/services/network/networkchain/simulate.go
@@ -114,18 +114,25 @@ func (c Chain) setSimulationConfig() (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	apiAddr, err := xurl.TCP(genAddr(ports[0]))
+	if err != nil {
+		return "", err
+	}
+
 	config.Set("api.enable", true)
 	config.Set("api.enabled-unsafe-cors", true)
 	config.Set("rpc.cors_allowed_origins", []string{"*"})
-	config.Set("api.address", xurl.TCP(genAddr(ports[0])))
+	config.Set("api.address", apiAddr)
 	config.Set("grpc.address", genAddr(ports[1]))
+
 	file, err := os.OpenFile(appPath, os.O_RDWR|os.O_TRUNC, 0644)
 	if err != nil {
 		return "", err
 	}
 	defer file.Close()
-	_, err = config.WriteTo(file)
-	if err != nil {
+
+	if _, err := config.WriteTo(file); err != nil {
 		return "", err
 	}
 
@@ -138,17 +145,30 @@ func (c Chain) setSimulationConfig() (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	rpcAddr, err := xurl.TCP(genAddr(ports[2]))
+	if err != nil {
+		return "", err
+	}
+
+	p2pAddr, err := xurl.TCP(genAddr(ports[3]))
+	if err != nil {
+		return "", err
+	}
+
 	config.Set("rpc.cors_allowed_origins", []string{"*"})
 	config.Set("consensus.timeout_commit", "1s")
 	config.Set("consensus.timeout_propose", "1s")
-	config.Set("rpc.laddr", xurl.TCP(genAddr(ports[2])))
-	config.Set("p2p.laddr", xurl.TCP(genAddr(ports[3])))
+	config.Set("rpc.laddr", rpcAddr)
+	config.Set("p2p.laddr", p2pAddr)
 	config.Set("rpc.pprof_laddr", genAddr(ports[4]))
+
 	file, err = os.OpenFile(configPath, os.O_RDWR|os.O_TRUNC, 0644)
 	if err != nil {
 		return "", err
 	}
 	defer file.Close()
+
 	_, err = config.WriteTo(file)
 
 	return genAddr(ports[0]), err
@@ -157,7 +177,12 @@ func (c Chain) setSimulationConfig() (string, error) {
 // isChainListening checks if the chain is listening for API queries on the specified address
 func isChainListening(ctx context.Context, addressAPI string) error {
 	checkAlive := func() error {
-		ok, err := httpstatuschecker.Check(ctx, xurl.HTTP(addressAPI)+"/node_info")
+		addr, err := xurl.HTTP(addressAPI)
+		if err != nil {
+			return fmt.Errorf("invalid api address format %s: %w", addressAPI, err)
+		}
+
+		ok, err := httpstatuschecker.Check(ctx, fmt.Sprintf("%s/node_info", addr))
 		if err == nil && !ok {
 			err = errors.New("app is not online")
 		}

--- a/integration/app/tx_test.go
+++ b/integration/app/tx_test.go
@@ -92,6 +92,11 @@ func TestGetTxViaGRPCGateway(t *testing.T) {
 					return errors.New("expected alice and bob accounts to be created")
 				}
 
+				nodeAddr, err := xurl.TCP(host.RPC) 
+				if err != nil {
+					return err
+				}
+
 				// send some tokens from alice to bob and confirm the corresponding tx via gRPC gateway
 				// endpoint by asserting denom and amount.
 				return cmdrunner.New().Run(ctx, step.New(
@@ -105,7 +110,7 @@ func TestGetTxViaGRPCGateway(t *testing.T) {
 						"10token",
 						"--keyring-backend", "test",
 						"--chain-id", appname,
-						"--node", xurl.TCP(host.RPC),
+						"--node", nodeAddr,
 						"--yes",
 					),
 					step.PreExec(func() error {
@@ -124,7 +129,12 @@ func TestGetTxViaGRPCGateway(t *testing.T) {
 							return err
 						}
 
-						addr := fmt.Sprintf("%s/cosmos/tx/v1beta1/txs/%s", xurl.HTTP(host.API), tx.Hash)
+						apiAddr, err := xurl.HTTP(host.API)
+						if err != nil {
+							return err
+						}
+
+						addr := fmt.Sprintf("%s/cosmos/tx/v1beta1/txs/%s", apiAddr, tx.Hash)
 						req, err := http.NewRequestWithContext(ctx, http.MethodGet, addr, nil)
 						if err != nil {
 							return errors.Wrap(err, "call to get tx via gRPC gateway")

--- a/integration/app/tx_test.go
+++ b/integration/app/tx_test.go
@@ -92,7 +92,7 @@ func TestGetTxViaGRPCGateway(t *testing.T) {
 					return errors.New("expected alice and bob accounts to be created")
 				}
 
-				nodeAddr, err := xurl.TCP(host.RPC) 
+				nodeAddr, err := xurl.TCP(host.RPC)
 				if err != nil {
 					return err
 				}

--- a/integration/env.go
+++ b/integration/env.go
@@ -347,7 +347,7 @@ func (e Env) ConfigureFaucet(path string, configFile string, coins, coinsMax []s
 	_, err = configyml.Seek(0, 0)
 	require.NoError(e.t, err)
 	require.NoError(e.t, yaml.NewEncoder(configyml).Encode(conf))
-	
+
 	addr, err := xurl.HTTP(fmt.Sprintf("0.0.0.0:%d", port[0]))
 	require.NoError(e.t, err)
 

--- a/integration/env.go
+++ b/integration/env.go
@@ -251,7 +251,12 @@ func (e Env) EnsureAppIsSteady(appPath string) {
 // before ctx canceled.
 func (e Env) IsAppServed(ctx context.Context, host chainconfig.Host) error {
 	checkAlive := func() error {
-		ok, err := httpstatuschecker.Check(ctx, xurl.HTTP(host.API)+"/node_info")
+		addr, err := xurl.HTTP(host.API)
+		if err != nil {
+			return err
+		}
+
+		ok, err := httpstatuschecker.Check(ctx, fmt.Sprintf("%s/node_info", addr))
 		if err == nil && !ok {
 			err = errors.New("app is not online")
 		}
@@ -342,8 +347,11 @@ func (e Env) ConfigureFaucet(path string, configFile string, coins, coinsMax []s
 	_, err = configyml.Seek(0, 0)
 	require.NoError(e.t, err)
 	require.NoError(e.t, yaml.NewEncoder(configyml).Encode(conf))
+	
+	addr, err := xurl.HTTP(fmt.Sprintf("0.0.0.0:%d", port[0]))
+	require.NoError(e.t, err)
 
-	return xurl.HTTP(fmt.Sprintf("0.0.0.0:%d", port[0]))
+	return addr
 }
 
 // SetRandomHomeConfig sets in the blockchain config files generated temporary directories for home directories

--- a/integration/faucet/faucet_test.go
+++ b/integration/faucet/faucet_test.go
@@ -59,8 +59,11 @@ func TestRequestCoinsFromFaucet(t *testing.T) {
 
 	// error "account doesn't have any balances" occurs if a sleep is not included
 	time.Sleep(time.Second * 1)
+	
+	nodeAddr, err := xurl.HTTP(servers.RPC)
+	require.NoError(t, err)
 
-	cosmosClient, err := cosmosclient.New(ctx, cosmosclient.WithNodeAddress(xurl.HTTP(servers.RPC)))
+	cosmosClient, err := cosmosclient.New(ctx, cosmosclient.WithNodeAddress(nodeAddr))
 	require.NoError(t, err)
 
 	// the faucet sends the default faucet coins value when not specified

--- a/integration/faucet/faucet_test.go
+++ b/integration/faucet/faucet_test.go
@@ -59,7 +59,7 @@ func TestRequestCoinsFromFaucet(t *testing.T) {
 
 	// error "account doesn't have any balances" occurs if a sleep is not included
 	time.Sleep(time.Second * 1)
-	
+
 	nodeAddr, err := xurl.HTTP(servers.RPC)
 	require.NoError(t, err)
 


### PR DESCRIPTION
fixes #2390

### Description

The protocol related functions should be refactored to avoid errors:
- [x] The URI value should not be empty
- [x] When the scheme exists it must be the one ensured by the function
- [x] When a different scheme exists it must be replaced by the ensured one
- [x] Protocol functions must be unit tested
- [x] The code using these functions must handle any parse error