### PR TITLE
fix(serve): fix custom p2p port from the `config.yml`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/briandowns/spinner v1.11.1
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/charmbracelet/glow v1.4.0
-	github.com/cosmos/cosmos-sdk v0.45.3
+	github.com/cosmos/cosmos-sdk v0.45.4
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/cosmos/ibc-go/v2 v2.0.3
 	github.com/docker/docker v20.10.7+incompatible

--- a/go.sum
+++ b/go.sum
@@ -424,6 +424,8 @@ github.com/cosmos/btcutil v1.0.4/go.mod h1:Ffqc8Hn6TJUdDgHBwIZLtrLQC1KdJ9jGJl/Tv
 github.com/cosmos/cosmos-sdk v0.44.5/go.mod h1:maUA6m2TBxOJZkbwl0eRtEBgTX37kcaiOWU5t1HEGaY=
 github.com/cosmos/cosmos-sdk v0.45.3 h1:PiVSU3IkNEDPhoxOZHk2lPnhwBBJgEYAtAR0jGXRN4g=
 github.com/cosmos/cosmos-sdk v0.45.3/go.mod h1:qYm5JEr0ZlbnmoP/Q3b+dYMOliHf4ddHirpILiwZzqg=
+github.com/cosmos/cosmos-sdk v0.45.4 h1:eStDAhJdMY8n5arbBRe+OwpNeBSunxSBHp1g55ulfdA=
+github.com/cosmos/cosmos-sdk v0.45.4/go.mod h1:WOqtDxN3eCCmnYLVla10xG7lEXkFjpTaqm2a2WasgCc=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=

--- a/ignite/cmd/cmd.go
+++ b/ignite/cmd/cmd.go
@@ -10,6 +10,9 @@ import (
 	"time"
 
 	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cosmosaccount"
 	"github.com/ignite-hq/cli/ignite/pkg/cosmosver"
 	"github.com/ignite-hq/cli/ignite/pkg/gitpod"
@@ -18,8 +21,6 @@ import (
 	"github.com/ignite-hq/cli/ignite/services/chain"
 	"github.com/ignite-hq/cli/ignite/services/scaffolder"
 	"github.com/ignite-hq/cli/ignite/version"
-	"github.com/spf13/cobra"
-	flag "github.com/spf13/pflag"
 )
 
 const (

--- a/ignite/cmd/network_campaign_account.go
+++ b/ignite/cmd/network_campaign_account.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"strconv"
 
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/icons"
 	"github.com/ignite-hq/cli/ignite/services/network"
 	"github.com/ignite-hq/cli/ignite/services/network/networktypes"
-	"github.com/spf13/cobra"
-	"golang.org/x/sync/errgroup"
 )
 
 var (

--- a/ignite/cmd/network_campaign_list.go
+++ b/ignite/cmd/network_campaign_list.go
@@ -3,10 +3,11 @@ package ignitecmd
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/entrywriter"
 	"github.com/ignite-hq/cli/ignite/services/network/networktypes"
-	"github.com/spf13/cobra"
 )
 
 var CampaignSummaryHeader = []string{

--- a/ignite/cmd/network_campaign_publish.go
+++ b/ignite/cmd/network_campaign_publish.go
@@ -2,9 +2,10 @@ package ignitecmd
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/spf13/cobra"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/icons"
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/ignite/cmd/network_campaign_show.go
+++ b/ignite/cmd/network_campaign_show.go
@@ -1,10 +1,11 @@
 package ignitecmd
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/pkg/yaml"
 	"github.com/ignite-hq/cli/ignite/services/network"
-	"github.com/spf13/cobra"
 )
 
 // NewNetworkCampaignShow returns a new command to show published campaign on Ignite

--- a/ignite/cmd/network_campaign_update.go
+++ b/ignite/cmd/network_campaign_update.go
@@ -5,10 +5,11 @@ import (
 	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/spf13/cobra"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/pkg/yaml"
 	"github.com/ignite-hq/cli/ignite/services/network"
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/ignite/cmd/network_chain_init.go
+++ b/ignite/cmd/network_chain_init.go
@@ -3,6 +3,8 @@ package ignitecmd
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/cliquiz"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/icons"
@@ -11,7 +13,6 @@ import (
 	"github.com/ignite-hq/cli/ignite/services/chain"
 	"github.com/ignite-hq/cli/ignite/services/network"
 	"github.com/ignite-hq/cli/ignite/services/network/networkchain"
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/ignite/cmd/network_chain_install.go
+++ b/ignite/cmd/network_chain_install.go
@@ -3,13 +3,14 @@ package ignitecmd
 import (
 	"path/filepath"
 
+	"github.com/spf13/cobra"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/colors"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/icons"
 	"github.com/ignite-hq/cli/ignite/pkg/goenv"
 	"github.com/ignite-hq/cli/ignite/services/network"
 	"github.com/ignite-hq/cli/ignite/services/network/networkchain"
-	"github.com/spf13/cobra"
 )
 
 // NewNetworkChainInstall returns a new command to install a chain's binary by the launch id.

--- a/ignite/cmd/network_chain_join.go
+++ b/ignite/cmd/network_chain_join.go
@@ -5,6 +5,10 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/pkg/errors"
+	"github.com/rdegges/go-ipify"
+	"github.com/spf13/cobra"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/cliquiz"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/icons"
@@ -12,9 +16,6 @@ import (
 	"github.com/ignite-hq/cli/ignite/pkg/xchisel"
 	"github.com/ignite-hq/cli/ignite/services/network"
 	"github.com/ignite-hq/cli/ignite/services/network/networkchain"
-	"github.com/pkg/errors"
-	"github.com/rdegges/go-ipify"
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/ignite/cmd/network_chain_launch.go
+++ b/ignite/cmd/network_chain_launch.go
@@ -1,9 +1,10 @@
 package ignitecmd
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/services/network"
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/ignite/cmd/network_chain_list.go
+++ b/ignite/cmd/network_chain_list.go
@@ -3,11 +3,12 @@ package ignitecmd
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/entrywriter"
 	"github.com/ignite-hq/cli/ignite/services/network"
 	"github.com/ignite-hq/cli/ignite/services/network/networktypes"
-	"github.com/spf13/cobra"
 )
 
 var LaunchSummaryHeader = []string{"launch ID", "chain ID", "source", "campaign ID", "network", "reward"}

--- a/ignite/cmd/network_chain_prepare.go
+++ b/ignite/cmd/network_chain_prepare.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/spf13/cobra"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/colors"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/icons"
 	"github.com/ignite-hq/cli/ignite/pkg/goenv"
 	"github.com/ignite-hq/cli/ignite/services/network"
 	"github.com/ignite-hq/cli/ignite/services/network/networkchain"
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/ignite/cmd/network_chain_publish.go
+++ b/ignite/cmd/network_chain_publish.go
@@ -5,16 +5,17 @@ import (
 	"os"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/tendermint/spn/pkg/chainid"
+	campaigntypes "github.com/tendermint/spn/x/campaign/types"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/icons"
 	"github.com/ignite-hq/cli/ignite/pkg/cosmosutil"
 	"github.com/ignite-hq/cli/ignite/pkg/xurl"
 	"github.com/ignite-hq/cli/ignite/services/network"
 	"github.com/ignite-hq/cli/ignite/services/network/networkchain"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	"github.com/tendermint/spn/pkg/chainid"
-	campaigntypes "github.com/tendermint/spn/x/campaign/types"
 )
 
 const (

--- a/ignite/cmd/network_chain_revert_launch.go
+++ b/ignite/cmd/network_chain_revert_launch.go
@@ -1,10 +1,11 @@
 package ignitecmd
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/services/network"
 	"github.com/ignite-hq/cli/ignite/services/network/networkchain"
-	"github.com/spf13/cobra"
 )
 
 // NewNetworkChainRevertLaunch creates a new chain revert launch command

--- a/ignite/cmd/network_chain_show.go
+++ b/ignite/cmd/network_chain_show.go
@@ -1,9 +1,10 @@
 package ignitecmd
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/services/network"
-	"github.com/spf13/cobra"
 )
 
 const flagOut = "out"

--- a/ignite/cmd/network_chain_show_accounts.go
+++ b/ignite/cmd/network_chain_show_accounts.go
@@ -3,9 +3,10 @@ package ignitecmd
 import (
 	"strconv"
 
+	"github.com/spf13/cobra"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/icons"
-	"github.com/spf13/cobra"
 )
 
 var (

--- a/ignite/cmd/network_chain_show_genesis.go
+++ b/ignite/cmd/network_chain_show_genesis.go
@@ -4,10 +4,11 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/spf13/cobra"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/icons"
 	"github.com/ignite-hq/cli/ignite/services/network/networkchain"
-	"github.com/spf13/cobra"
 )
 
 func newNetworkChainShowGenesis() *cobra.Command {

--- a/ignite/cmd/network_chain_show_info.go
+++ b/ignite/cmd/network_chain_show_info.go
@@ -1,12 +1,13 @@
 package ignitecmd
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/pkg/cosmosutil"
 	"github.com/ignite-hq/cli/ignite/pkg/yaml"
 	"github.com/ignite-hq/cli/ignite/services/network"
 	"github.com/ignite-hq/cli/ignite/services/network/networktypes"
-	"github.com/spf13/cobra"
 )
 
 func newNetworkChainShowInfo() *cobra.Command {

--- a/ignite/cmd/network_chain_show_peers.go
+++ b/ignite/cmd/network_chain_show_peers.go
@@ -7,10 +7,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/icons"
 	"github.com/ignite-hq/cli/ignite/services/network"
-	"github.com/spf13/cobra"
 )
 
 func newNetworkChainShowPeers() *cobra.Command {

--- a/ignite/cmd/network_chain_show_validators.go
+++ b/ignite/cmd/network_chain_show_validators.go
@@ -1,10 +1,11 @@
 package ignitecmd
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/icons"
 	"github.com/ignite-hq/cli/ignite/services/network"
-	"github.com/spf13/cobra"
 )
 
 var (

--- a/ignite/cmd/network_request_approve.go
+++ b/ignite/cmd/network_request_approve.go
@@ -1,12 +1,13 @@
 package ignitecmd
 
 import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/icons"
 	"github.com/ignite-hq/cli/ignite/pkg/numbers"
 	"github.com/ignite-hq/cli/ignite/services/network"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/ignite/cmd/network_request_list.go
+++ b/ignite/cmd/network_request_list.go
@@ -3,11 +3,12 @@ package ignitecmd
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+	launchtypes "github.com/tendermint/spn/x/launch/types"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/services/network"
 	"github.com/ignite-hq/cli/ignite/services/network/networktypes"
-	"github.com/spf13/cobra"
-	launchtypes "github.com/tendermint/spn/x/launch/types"
 )
 
 var requestSummaryHeader = []string{"ID", "Status", "Type", "Content"}

--- a/ignite/cmd/network_request_reject.go
+++ b/ignite/cmd/network_request_reject.go
@@ -1,11 +1,12 @@
 package ignitecmd
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/icons"
 	"github.com/ignite-hq/cli/ignite/pkg/numbers"
 	"github.com/ignite-hq/cli/ignite/services/network"
-	"github.com/spf13/cobra"
 )
 
 // NewNetworkRequestReject creates a new request reject

--- a/ignite/cmd/network_request_show.go
+++ b/ignite/cmd/network_request_show.go
@@ -3,11 +3,12 @@ package ignitecmd
 import (
 	"strconv"
 
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/pkg/yaml"
 	"github.com/ignite-hq/cli/ignite/services/network"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 )
 
 // NewNetworkRequestShow creates a new request show command to show

--- a/ignite/cmd/network_request_verify.go
+++ b/ignite/cmd/network_request_verify.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/ignite-hq/cli/ignite/pkg/chaincmd"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/icons"
 	"github.com/ignite-hq/cli/ignite/pkg/numbers"
 	"github.com/ignite-hq/cli/ignite/services/network"
 	"github.com/ignite-hq/cli/ignite/services/network/networkchain"
-	"github.com/spf13/cobra"
 )
 
 // NewNetworkRequestVerify verify the request and simulate the chain.

--- a/ignite/cmd/network_reward_set.go
+++ b/ignite/cmd/network_reward_set.go
@@ -5,9 +5,10 @@ import (
 	"strconv"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/spf13/cobra"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/services/network"
-	"github.com/spf13/cobra"
 )
 
 // NewNetworkRewardSet creates a new chain reward set command to

--- a/ignite/pkg/cliui/cliui.go
+++ b/ignite/pkg/cliui/cliui.go
@@ -6,12 +6,13 @@ import (
 	"os"
 	"sync"
 
+	"github.com/manifoldco/promptui"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/cliquiz"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/clispinner"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/entrywriter"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/icons"
 	"github.com/ignite-hq/cli/ignite/pkg/events"
-	"github.com/manifoldco/promptui"
 )
 
 // Session controls command line interaction with users.

--- a/ignite/pkg/cliui/entrywriter/entrywriter_test.go
+++ b/ignite/pkg/cliui/entrywriter/entrywriter_test.go
@@ -2,11 +2,12 @@ package entrywriter_test
 
 import (
 	"errors"
-	"github.com/ignite-hq/cli/ignite/pkg/cliui/entrywriter"
 	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/ignite-hq/cli/ignite/pkg/cliui/entrywriter"
 )
 
 type WriterWithError struct{}

--- a/ignite/pkg/events/events_test.go
+++ b/ignite/pkg/events/events_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 
 	"github.com/gookit/color"
-	"github.com/ignite-hq/cli/ignite/pkg/events"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ignite-hq/cli/ignite/pkg/events"
 )
 
 func TestBusSend(t *testing.T) {

--- a/ignite/pkg/xurl/xurl.go
+++ b/ignite/pkg/xurl/xurl.go
@@ -91,38 +91,12 @@ func HTTPEnsurePort(s string) string {
 	return u.String()
 }
 
-// CleanPath cleans path from the url.
-func CleanPath(s string) string {
-	u, err := url.Parse(s)
-	if err != nil {
-		return s
-	}
-
-	u.Path = ""
-
-	return u.String()
-}
-
 // Address ensures that address contains localhost as host if non specified.
 func Address(address string) string {
 	if strings.HasPrefix(address, ":") {
 		return "localhost" + address
 	}
 	return address
-}
-
-// IsLocalPath checks if given address is a local fs path or a URL.
-func IsLocalPath(address string) bool {
-	for _, pattern := range []string{
-		"http://",
-		"https://",
-		"git@",
-	} {
-		if strings.HasPrefix(address, pattern) {
-			return false
-		}
-	}
-	return true
 }
 
 func IsHTTP(address string) bool {

--- a/ignite/pkg/xurl/xurl_test.go
+++ b/ignite/pkg/xurl/xurl_test.go
@@ -326,3 +326,53 @@ func TestMightHTTPS(t *testing.T) {
 		})
 	}
 }
+
+func Test_addressPort(t *testing.T) {
+	tests := []struct {
+		name     string
+		arg      string
+		wantHost string
+		want     bool
+	}{
+		{
+			name: "URI path",
+			arg:  "/test/false",
+			want: false,
+		},
+		{
+			name: "invalid address",
+			arg:  "aeihf3/aef/f..//",
+			want: false,
+		},
+		{
+			name:     "host and port",
+			arg:      "102.33.3.43:10000",
+			wantHost: "102.33.3.43:10000",
+			want:     true,
+		},
+		{
+			name:     "local port",
+			arg:      "0.0.0.0:10000",
+			wantHost: "0.0.0.0:10000",
+			want:     true,
+		},
+		{
+			name:     "only port",
+			arg:      ":10000",
+			wantHost: "0.0.0.0:10000",
+			want:     true,
+		},
+		{
+			name: "only host",
+			arg:  "102.33.3.43",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotHost, got := addressPort(tt.arg)
+			require.Equal(t, tt.want, got)
+			require.Equal(t, tt.wantHost, gotHost)
+		})
+	}
+}

--- a/ignite/services/network/reward.go
+++ b/ignite/services/network/reward.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	rewardtypes "github.com/tendermint/spn/x/reward/types"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/icons"
 	"github.com/ignite-hq/cli/ignite/pkg/events"
 	"github.com/ignite-hq/cli/ignite/services/network/networktypes"
-	rewardtypes "github.com/tendermint/spn/x/reward/types"
 )
 
 // SetReward set a chain reward

--- a/ignite/templates/app/stargate/go.mod.plush
+++ b/ignite/templates/app/stargate/go.mod.plush
@@ -3,7 +3,7 @@ module <%= ModulePath %>
 go 1.16
 
 require (
-	github.com/cosmos/cosmos-sdk v0.45.3
+	github.com/cosmos/cosmos-sdk v0.45.4
 	github.com/cosmos/ibc-go/v2 v2.0.3
 	github.com/gogo/protobuf v1.3.3
 	github.com/golang/protobuf v1.5.2

--- a/ignite/templates/app/stargate/go.sum
+++ b/ignite/templates/app/stargate/go.sum
@@ -465,8 +465,9 @@ github.com/cosmos/cosmos-sdk v0.44.4/go.mod h1:0QTCOkE8IWu5LZyfnbbjFjxYRIcV4pBOr
 github.com/cosmos/cosmos-sdk v0.44.5/go.mod h1:maUA6m2TBxOJZkbwl0eRtEBgTX37kcaiOWU5t1HEGaY=
 github.com/cosmos/cosmos-sdk v0.45.1/go.mod h1:XXS/asyCqWNWkx2rW6pSuen+EVcpAFxq6khrhnZgHaQ=
 github.com/cosmos/cosmos-sdk v0.45.2/go.mod h1:DhSVBqJkhjB694w99FudptzPhU0XHd/qcyiNCLOjkds=
-github.com/cosmos/cosmos-sdk v0.45.3 h1:PiVSU3IkNEDPhoxOZHk2lPnhwBBJgEYAtAR0jGXRN4g=
 github.com/cosmos/cosmos-sdk v0.45.3/go.mod h1:qYm5JEr0ZlbnmoP/Q3b+dYMOliHf4ddHirpILiwZzqg=
+github.com/cosmos/cosmos-sdk v0.45.4 h1:eStDAhJdMY8n5arbBRe+OwpNeBSunxSBHp1g55ulfdA=
+github.com/cosmos/cosmos-sdk v0.45.4/go.mod h1:WOqtDxN3eCCmnYLVla10xG7lEXkFjpTaqm2a2WasgCc=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=


### PR DESCRIPTION
# Headline

Add a custom P2P host port into the `config.yml` is not serving the app after the cosmos-sdk update; The current P2P cosmos library is breaking after adding the port without the host (`:26658`). We need to pass with the host (`0.0.0.0:26658`)

### Fix

- Update `cosmos-sdk` version;
- Force the host if not provided;