### PR TITLE
fix(network): fix validator pubkey parser from gentx

### DIFF
--- a/ignite/pkg/cosmosgen/cosmosgen_test.go
+++ b/ignite/pkg/cosmosgen/cosmosgen_test.go
@@ -3,9 +3,10 @@ package cosmosgen
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ignite-hq/cli/ignite/pkg/cosmosanalysis/module"
 	"github.com/ignite-hq/cli/ignite/pkg/protoanalysis"
-	"github.com/stretchr/testify/require"
 )
 
 func TestVuexStoreModulePath(t *testing.T) {

--- a/ignite/pkg/cosmosutil/gentx.go
+++ b/ignite/pkg/cosmosutil/gentx.go
@@ -1,10 +1,13 @@
 package cosmosutil
 
 import (
-	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
+
+	"github.com/tendermint/tendermint/crypto/ed25519"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -12,13 +15,10 @@ import (
 var GentxFilename = "gentx.json"
 
 type (
-	// PubKey represents the public key in bytes array
-	PubKey []byte
-
 	// GentxInfo represents the basic info about gentx file
 	GentxInfo struct {
 		DelegatorAddress string
-		PubKey           PubKey
+		PubKey           ed25519.PubKey
 		SelfDelegation   sdk.Coin
 		Memo             string
 	}
@@ -30,7 +30,8 @@ type (
 				DelegatorAddress string `json:"delegator_address"`
 				ValidatorAddress string `json:"validator_address"`
 				PubKey           struct {
-					Key string `json:"key"`
+					Type string `json:"@type"`
+					Key  string `json:"key"`
 				} `json:"pubkey"`
 				Value struct {
 					Denom  string `json:"denom"`
@@ -41,12 +42,6 @@ type (
 		} `json:"body"`
 	}
 )
-
-// Equal returns true if the public keys are equal
-func (pb PubKey) Equal(key []byte) bool {
-	res := bytes.Compare(pb, key)
-	return res == 0
-}
 
 // GentxFromPath returns GentxInfo from the json file
 func GentxFromPath(path string) (info GentxInfo, gentx []byte, err error) {
@@ -80,7 +75,12 @@ func ParseGentx(gentx []byte) (info GentxInfo, file []byte, err error) {
 
 	info.Memo = stargateGentx.Body.Memo
 	info.DelegatorAddress = stargateGentx.Body.Messages[0].DelegatorAddress
-	info.PubKey = []byte(stargateGentx.Body.Messages[0].PubKey.Key)
+
+	pb := stargateGentx.Body.Messages[0].PubKey.Key
+	info.PubKey, err = base64.StdEncoding.DecodeString(pb)
+	if err != nil {
+		return info, gentx, fmt.Errorf("invalid validator public key %s", err.Error())
+	}
 
 	amount, ok := sdk.NewIntFromString(stargateGentx.Body.Messages[0].Value.Amount)
 	if !ok {

--- a/ignite/pkg/cosmosutil/gentx_test.go
+++ b/ignite/pkg/cosmosutil/gentx_test.go
@@ -1,15 +1,22 @@
 package cosmosutil_test
 
 import (
+	"encoding/base64"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/crypto/ed25519"
 
 	"github.com/ignite-hq/cli/ignite/pkg/cosmosutil"
 )
 
 func TestParseGentx(t *testing.T) {
+	pk1, err := base64.StdEncoding.DecodeString("aeQLCJOjXUyB7evOodI4mbrshIt3vhHGlycJDbUkaMs=")
+	require.NoError(t, err)
+	pk2, err := base64.StdEncoding.DecodeString("OL+EIoo7DwyaBFDbPbgAhwS5rvgIqoUa0x8qWqzfQVQ=")
+	require.NoError(t, err)
+
 	tests := []struct {
 		name      string
 		gentxPath string
@@ -21,7 +28,7 @@ func TestParseGentx(t *testing.T) {
 			gentxPath: "testdata/gentx1.json",
 			wantInfo: cosmosutil.GentxInfo{
 				DelegatorAddress: "cosmos1dd246yq6z5vzjz9gh8cff46pll75yyl8ygndsj",
-				PubKey:           []byte("aeQLCJOjXUyB7evOodI4mbrshIt3vhHGlycJDbUkaMs="),
+				PubKey:           ed25519.PubKey(pk1),
 				SelfDelegation: sdk.Coin{
 					Denom:  "stake",
 					Amount: sdk.NewInt(95000000),
@@ -33,7 +40,7 @@ func TestParseGentx(t *testing.T) {
 			gentxPath: "testdata/gentx2.json",
 			wantInfo: cosmosutil.GentxInfo{
 				DelegatorAddress: "cosmos1mmlqwyqk7neqegffp99q86eckpm4pjah3ytlpa",
-				PubKey:           []byte("OL+EIoo7DwyaBFDbPbgAhwS5rvgIqoUa0x8qWqzfQVQ="),
+				PubKey:           ed25519.PubKey(pk2),
 				SelfDelegation: sdk.Coin{
 					Denom:  "stake",
 					Amount: sdk.NewInt(95000000),

--- a/ignite/pkg/cosmosutil/gentx_test.go
+++ b/ignite/pkg/cosmosutil/gentx_test.go
@@ -62,32 +62,3 @@ func TestParseGentx(t *testing.T) {
 		})
 	}
 }
-
-func TestPubKey_Equal(t *testing.T) {
-	tests := []struct {
-		name   string
-		pb     []byte
-		cmpKey []byte
-		want   bool
-	}{
-		{
-			name:   "equal public keys",
-			pb:     []byte("aeQLCJOjXUyB7evOodI4mbrshIt3vhHGlycJDbUkaMs="),
-			cmpKey: []byte("aeQLCJOjXUyB7evOodI4mbrshIt3vhHGlycJDbUkaMs="),
-			want:   true,
-		},
-		{
-			name:   "not equal public keys",
-			pb:     []byte("aeQLCJOjXUyB7evOodI4mbrshIt3vhHGlycJDbUkaMs="),
-			cmpKey: []byte("EIoo7DwyaBFDbPbgAhwS5rvgIqoUa0x8qWqzfQVQ="),
-			want:   false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			pb := cosmosutil.PubKey(tt.pb)
-			got := pb.Equal(tt.cmpKey)
-			require.Equal(t, tt.want, got)
-		})
-	}
-}

--- a/ignite/services/network/networktypes/request.go
+++ b/ignite/services/network/networktypes/request.go
@@ -84,8 +84,8 @@ func VerifyAddValidatorRequest(req *launchtypes.RequestContent_GenesisValidator)
 	if !info.PubKey.Equals(ed25519.PubKey(consPubKey)) {
 		return fmt.Errorf(
 			"the consensus pub key %s doesn't match the one inside the gentx %s",
-			string(consPubKey),
-			string(info.PubKey),
+			ed25519.PubKey(consPubKey).String(),
+			info.PubKey.String(),
 		)
 	}
 

--- a/ignite/services/network/networktypes/request.go
+++ b/ignite/services/network/networktypes/request.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	launchtypes "github.com/tendermint/spn/x/launch/types"
+	"github.com/tendermint/tendermint/crypto/ed25519"
 
 	"github.com/ignite-hq/cli/ignite/pkg/cosmosutil"
 	"github.com/ignite-hq/cli/ignite/pkg/xtime"
@@ -80,7 +81,7 @@ func VerifyAddValidatorRequest(req *launchtypes.RequestContent_GenesisValidator)
 	}
 
 	// Check validator address
-	if !info.PubKey.Equal(consPubKey) {
+	if !info.PubKey.Equals(ed25519.PubKey(consPubKey)) {
 		return fmt.Errorf(
 			"the consensus pub key %s doesn't match the one inside the gentx %s",
 			string(consPubKey),

--- a/ignite/services/network/networktypes/request_test.go
+++ b/ignite/services/network/networktypes/request_test.go
@@ -1,12 +1,14 @@
 package networktypes_test
 
 import (
+	"encoding/base64"
 	"fmt"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 	launchtypes "github.com/tendermint/spn/x/launch/types"
+	"github.com/tendermint/tendermint/crypto/ed25519"
 
 	"github.com/ignite-hq/cli/ignite/services/network/networktypes"
 )
@@ -30,6 +32,8 @@ func TestVerifyAddValidatorRequest(t *testing.T) {
     ]
   }
 }`)
+	pk, err := base64.StdEncoding.DecodeString("aeQLCJOjXUyB7evOodI4mbrshIt3vhHGlycJDbUkaMs=")
+	require.NoError(t, err)
 
 	tests := []struct {
 		name string
@@ -42,7 +46,7 @@ func TestVerifyAddValidatorRequest(t *testing.T) {
 				GenesisValidator: &launchtypes.GenesisValidator{
 					Address:        "spn1dd246yq6z5vzjz9gh8cff46pll75yyl8c5tt7g",
 					GenTx:          gentx,
-					ConsPubKey:     []byte("aeQLCJOjXUyB7evOodI4mbrshIt3vhHGlycJDbUkaMs="),
+					ConsPubKey:     ed25519.PubKey(pk),
 					SelfDelegation: sdk.NewCoin("stake", sdk.NewInt(95000000)),
 					Peer:           launchtypes.NewPeerConn("nodeid", "127.163.0.1:2446"),
 				},
@@ -54,7 +58,7 @@ func TestVerifyAddValidatorRequest(t *testing.T) {
 				GenesisValidator: &launchtypes.GenesisValidator{
 					Address:        "spn1dd246yq6z5vzjz9gh8cff46pll75yyl8c5tt7g",
 					GenTx:          gentx,
-					ConsPubKey:     []byte("aeQLCJOjXUyB7evOodI4mbrshIt3vhHGlycJDbUkaMs="),
+					ConsPubKey:     ed25519.PubKey(pk),
 					SelfDelegation: sdk.NewCoin("stake", sdk.NewInt(95000000)),
 					Peer:           launchtypes.NewPeerConn("nodeid", "122.114.800.11"),
 				},
@@ -67,7 +71,7 @@ func TestVerifyAddValidatorRequest(t *testing.T) {
 				GenesisValidator: &launchtypes.GenesisValidator{
 					Address:        "spn1dd246yq6z5vzjz9gh8cff46pll75yyl8c5tt7g",
 					GenTx:          []byte(`{}`),
-					ConsPubKey:     []byte("aeQLCJOjXUyB7evOodI4mbrshIt3vhHGlycJDbUkaMs="),
+					ConsPubKey:     ed25519.PubKey(pk),
 					SelfDelegation: sdk.NewCoin("stake", sdk.NewInt(95000000)),
 					Peer:           launchtypes.NewPeerConn("nodeid", "127.163.0.1:2446"),
 				},
@@ -80,7 +84,7 @@ func TestVerifyAddValidatorRequest(t *testing.T) {
 				GenesisValidator: &launchtypes.GenesisValidator{
 					Address:        "spn1dd246yq6z5vzjz9gh8cff46pll75yyl8c5tt7g",
 					GenTx:          gentx,
-					ConsPubKey:     []byte("aeQLCJOjXUyB7evOodI4mbrshIt3vhHGlycJDbUkaMs="),
+					ConsPubKey:     ed25519.PubKey(pk),
 					SelfDelegation: sdk.NewCoin("foo", sdk.NewInt(95000000)),
 					Peer:           launchtypes.NewPeerConn("nodeid", "127.163.0.1:2446"),
 				},
@@ -93,7 +97,7 @@ func TestVerifyAddValidatorRequest(t *testing.T) {
 				GenesisValidator: &launchtypes.GenesisValidator{
 					Address:        "spn1dd246yq6z5vzjz9gh8cff46pll75yyl8c5tt7g",
 					GenTx:          gentx,
-					ConsPubKey:     []byte("aeQLCJOjXUyB7evOodI4mbrshIt3vhHGlycJDbUkaMs="),
+					ConsPubKey:     ed25519.PubKey(pk),
 					SelfDelegation: sdk.NewCoin("stake", sdk.NewInt(3)),
 					Peer:           launchtypes.NewPeerConn("nodeid", "127.163.0.1:2446"),
 				},
@@ -106,12 +110,12 @@ func TestVerifyAddValidatorRequest(t *testing.T) {
 				GenesisValidator: &launchtypes.GenesisValidator{
 					Address:        "spn1dd246yq6z5vzjz9gh8cff46pll75yyl8c5tt7g",
 					GenTx:          gentx,
-					ConsPubKey:     []byte("cosmos1gkheudhhjsvq0s8fxt7p6pwe0k3k30kepcnz9p="),
+					ConsPubKey:     ed25519.PubKey("cosmos1gkheudhhjsvq0s8fxt7p6pwe0k3k30kepcnz9p="),
 					SelfDelegation: sdk.NewCoin("stake", sdk.NewInt(95000000)),
 					Peer:           launchtypes.NewPeerConn("nodeid", "127.163.0.1:2446"),
 				},
 			},
-			want: fmt.Errorf("the consensus pub key cosmos1gkheudhhjsvq0s8fxt7p6pwe0k3k30kepcnz9p= doesn't match the one inside the gentx aeQLCJOjXUyB7evOodI4mbrshIt3vhHGlycJDbUkaMs="),
+			want: fmt.Errorf("the consensus pub key PubKeyEd25519{636F736D6F7331676B6865756468686A737671307338667874377036707765306B336B33306B6570636E7A39703D} doesn't match the one inside the gentx PubKeyEd25519{69E40B0893A35D4C81EDEBCEA1D23899BAEC848B77BE11C69727090DB52468CB}"),
 		},
 		{
 			name: "invalid validator address",
@@ -119,7 +123,7 @@ func TestVerifyAddValidatorRequest(t *testing.T) {
 				GenesisValidator: &launchtypes.GenesisValidator{
 					Address:        "spn1gkheudhhjsvq0s8fxt7p6pwe0k3k30keaytytm",
 					GenTx:          gentx,
-					ConsPubKey:     []byte("aeQLCJOjXUyB7evOodI4mbrshIt3vhHGlycJDbUkaMs="),
+					ConsPubKey:     ed25519.PubKey(pk),
 					SelfDelegation: sdk.NewCoin("stake", sdk.NewInt(95000000)),
 					Peer:           launchtypes.NewPeerConn("nodeid", "127.163.0.1:2446"),
 				},


### PR DESCRIPTION
# Description

We are parsing the pubkey wrong as a simple byte array, we should decode to `base64` and wrapper into an `ed25519` pubkey