### PR TITLE
fix: shell completion generation when new version is available

### DIFF
--- a/ignite/cmd/cmd.go
+++ b/ignite/cmd/cmd.go
@@ -35,10 +35,8 @@ const (
 )
 
 // New creates a new root command for `Ignite CLI` with its sub commands.
-func New(ctx context.Context) *cobra.Command {
+func New() *cobra.Command {
 	cobra.EnableCommandSorting = false
-
-	checkNewVersion(ctx)
 
 	c := &cobra.Command{
 		Use:   "ignite",
@@ -53,6 +51,12 @@ ignite scaffold chain github.com/username/mars`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// Check for new versions only when shell completion scripts are not being
+			// generated to avoid invalid output to stdout when a new version is available
+			if cmd.Use != "completions" {
+				checkNewVersion(cmd.Context())
+			}
+
 			return goenv.ConfigurePath()
 		},
 	}

--- a/ignite/cmd/ignite/main.go
+++ b/ignite/cmd/ignite/main.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	ctx := clictx.From(context.Background())
 
-	err := ignitecmd.New(ctx).ExecuteContext(ctx)
+	err := ignitecmd.New().ExecuteContext(ctx)
 
 	if ctx.Err() == context.Canceled || err == context.Canceled {
 		fmt.Println("aborted")

--- a/ignite/internal/tools/gen-cli-docs/main.go
+++ b/ignite/internal/tools/gen-cli-docs/main.go
@@ -5,7 +5,6 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -37,7 +36,7 @@ func main() {
 	outPath := flag.String("out", ".", ".md file path to place Ignite CLI docs inside")
 	flag.Parse()
 
-	if err := generate(ignitecmd.New(context.Background()), *outPath); err != nil {
+	if err := generate(ignitecmd.New(), *outPath); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
Closes #2468

The fix avoids invalid output to stdout when a new Ignite CLI version is available.