### PR TITLE
chore: gh workflows: bump github-repo-stats to 1.4.0

### DIFF
--- a/.github/workflows/stats.yaml
+++ b/.github/workflows/stats.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: run-ghrs
-        uses: jgehrcke/github-repo-stats@v1.1.0
+        uses: jgehrcke/github-repo-stats@v1.4.0
         with:
           ghtoken: ${{ secrets.ghrs_github_api_token }}
 


### PR DESCRIPTION
Hello! Thanks for using github-repo-stats! I suppose you're interested in using a more recent version :) Release notes for the past few releases can be found here: https://github.com/jgehrcke/github-repo-stats/releases