### PR TITLE
fix(cosmosgen): unset `NODE_OPTIONS` to avoid configuration conflicts

### DIFF
--- a/ignite/pkg/cosmosgen/generate_javascript.go
+++ b/ignite/pkg/cosmosgen/generate_javascript.go
@@ -126,6 +126,7 @@ func (g *jsGenerator) generateModule(ctx context.Context, tsprotoPluginPath, app
 		includePaths,
 		tsOut,
 		protoc.Plugin(tsprotoPluginPath, "--ts_proto_opt=snakeToCamel=false"),
+		protoc.Env("NODE_OPTIONS="), // unset nodejs options to avoid unexpected issues with vercel "pkg"
 	)
 	if err != nil {
 		return err

--- a/ignite/pkg/protoc/protoc.go
+++ b/ignite/pkg/protoc/protoc.go
@@ -23,6 +23,7 @@ type configs struct {
 	pluginPath             string
 	isGeneratedDepsEnabled bool
 	pluginOptions          []string
+	env                    []string
 }
 
 // Plugin configures a plugin for code generation.
@@ -38,6 +39,13 @@ func Plugin(path string, options ...string) Option {
 func GenerateDependencies() Option {
 	return func(c *configs) {
 		c.isGeneratedDepsEnabled = true
+	}
+}
+
+// Env assigns environment values during the code generation.
+func Env(v ...string) Option {
+	return func(c *configs) {
+		c.env = v
 	}
 }
 
@@ -119,10 +127,15 @@ func Generate(ctx context.Context, outDir, protoPath string, includePaths, proto
 		command = append(command, files...)
 		command = append(command, c.pluginOptions...)
 
-		if err := exec.Exec(ctx, command,
+		execOpts := []exec.Option{
 			exec.StepOption(step.Workdir(outDir)),
 			exec.IncludeStdLogsToError(),
-		); err != nil {
+		}
+		if c.env != nil {
+			execOpts = append(execOpts, exec.StepOption(step.Env(c.env...)))
+		}
+
+		if err := exec.Exec(ctx, command, execOpts...); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Closes #2521

If `NODE_OPTIONS` environment variable is setted when running `protoc` from the Ignite CLI it might cause unexpected issues with the [vercel "pkg"](https://github.com/vercel/pkg) (nodetime). It already happened before and it seems to be the cause of #2521.