### PR TITLE
fix: remove useless `tc := tc` in TDT tests and some of the templates

### DIFF
--- a/ignite/pkg/placeholder/tracer_test.go
+++ b/ignite/pkg/placeholder/tracer_test.go
@@ -39,7 +39,6 @@ func TestReplace(t *testing.T) {
 			missing: []string{"#one"},
 		},
 	} {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			tr := New()
 			content := tc.content
@@ -81,7 +80,6 @@ func TestReplaceAll(t *testing.T) {
 			missing: []string{"#one"},
 		},
 	} {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			tr := New()
 			content := tc.content

--- a/ignite/templates/typed/list/stargate/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/list/stargate/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
@@ -91,7 +91,6 @@ func TestUpdate<%= TypeName.UpperCamel %>(t *testing.T) {
 			code: sdkerrors.ErrKeyNotFound.ABCICode(),
 		},
 	} {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
             args := []string{tc.id}
             args = append(args, fields...)
@@ -147,7 +146,6 @@ func TestDelete<%= TypeName.UpperCamel %>(t *testing.T) {
 			code: sdkerrors.ErrKeyNotFound.ABCICode(),
 		},
 	} {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdDelete<%= TypeName.UpperCamel %>(), append([]string{tc.id}, tc.args...))
 			if tc.err != nil {

--- a/ignite/templates/typed/list/stargate/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/list/stargate/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
@@ -36,7 +36,6 @@ func TestCreate<%= TypeName.UpperCamel %>(t *testing.T) {
 			},
 		},
 	} {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
             args := []string{}
             args = append(args, fields...)

--- a/ignite/templates/typed/map/stargate/tests/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/map/stargate/tests/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
@@ -71,7 +71,6 @@ func TestShow<%= TypeName.UpperCamel %>(t *testing.T) {
 			err:  status.Error(codes.NotFound, "not found"),
 		},
 	} {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			args := []string{
 			    <%= for (i, index) in Indexes { %><%= index.ToString("tc.id" + index.Name.UpperCamel) %>,

--- a/ignite/templates/typed/map/stargate/tests/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/map/stargate/tests/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
@@ -44,7 +44,6 @@ func TestCreate<%= TypeName.UpperCamel %>(t *testing.T) {
 			},
 		},
 	} {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
             args := []string{
                 <%= for (i, index) in Indexes { %><%= index.ToString("tc.id" + index.Name.UpperCamel) %>,
@@ -108,7 +107,6 @@ func TestUpdate<%= TypeName.UpperCamel %>(t *testing.T) {
 			code: sdkerrors.ErrKeyNotFound.ABCICode(),
 		},
 	} {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
             args := []string{
                 <%= for (i, index) in Indexes { %><%= index.ToString("tc.id" + index.Name.UpperCamel) %>,
@@ -173,7 +171,6 @@ func TestDelete<%= TypeName.UpperCamel %>(t *testing.T) {
 			code: sdkerrors.ErrKeyNotFound.ABCICode(),
 		},
 	} {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 		    args := []string{
                 <%= for (i, index) in Indexes { %><%= index.ToString("tc.id" + index.Name.UpperCamel) %>,

--- a/ignite/templates/typed/singleton/stargate/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/singleton/stargate/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
@@ -49,7 +49,6 @@ func TestShow<%= TypeName.UpperCamel %>(t *testing.T) {
 			obj:  obj,
 		},
 	} {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			var args []string
 			args = append(args, tc.args...)

--- a/ignite/templates/typed/singleton/stargate/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/singleton/stargate/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
@@ -35,7 +35,6 @@ func TestCreate<%= TypeName.UpperCamel %>(t *testing.T) {
 			},
 		},
 	} {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
             var args []string
             args = append(args, fields...)
@@ -82,7 +81,6 @@ func TestUpdate<%= TypeName.UpperCamel %>(t *testing.T) {
 			args: common,
 		},
 	} {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
             var args []string
             args = append(args, fields...)
@@ -130,7 +128,6 @@ func TestDelete<%= TypeName.UpperCamel %>(t *testing.T) {
 			args: common,
 		},
 	} {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdDelete<%= TypeName.UpperCamel %>(), append([]string{}, tc.args...))
 			if tc.err != nil {


### PR DESCRIPTION
We have in several places in TDT the usage of `tc := tc`
Which is not necessary since `tc` is not a pointer

This PR removes every instance of this initialization in `tracer_test.go` and some of the templates