### PR TITLE
chore: change frontend docs to run it using `npm run dev`

### DIFF
--- a/docs/kb/frontend.md
+++ b/docs/kb/frontend.md
@@ -7,7 +7,7 @@ order: 8
 
 A Vue frontend app is created in the `vue` directory when a blockchain is scaffolded. To start the frontend app run `npm i && npm run dev` in the `vue` directory.
 
-The frontend app is built using the `@ignt/vue` and `@ignt/vuex` packages. For details, see the [monorepo for Ignite CLI front-end development](https://github.com/ignite-hq/web).
+The frontend app is built using the `@starport/vue` and `@starport/vuex` packages. For details, see the [monorepo for Ignite CLI front-end development](https://github.com/ignite-hq/web).
 
 ## Client code generation
 

--- a/docs/kb/frontend.md
+++ b/docs/kb/frontend.md
@@ -7,7 +7,7 @@ order: 8
 
 A Vue frontend app is created in the `vue` directory when a blockchain is scaffolded. To start the frontend app run `npm i && npm run dev` in the `vue` directory.
 
-The frontend app is built using the `@ignt/vue` and `@ignt/vuex` packages. For details, see the [monorepo for Ignite CLI front-end development](https://github.com/ignite-hq/vue).
+The frontend app is built using the `@ignt/vue` and `@ignt/vuex` packages. For details, see the [monorepo for Ignite CLI front-end development](https://github.com/ignite-hq/web).
 
 ## Client code generation
 

--- a/docs/kb/frontend.md
+++ b/docs/kb/frontend.md
@@ -5,7 +5,7 @@ order: 8
 
 # Frontend overview
 
-A Vue frontend app is created in the `vue` directory when a blockchain is scaffolded. To start the frontend app run `npm i && npm run serve` in the `vue` directory.
+A Vue frontend app is created in the `vue` directory when a blockchain is scaffolded. To start the frontend app run `npm i && npm run dev` in the `vue` directory.
 
 The frontend app is built using the `@ignt/vue` and `@ignt/vuex` packages. For details, see the [monorepo for Ignite CLI front-end development](https://github.com/ignite-hq/vue).
 


### PR DESCRIPTION
The frontend app should be run using `npm run dev` when following the CLI tutorial.

Running it using `npm run serve` requires an extra step to build the app, which at the moment is causing some issues. See #2503.