### PR TITLE
feat(network): add `address-prefix` flag for printing commands

### DIFF
--- a/ignite/cmd/account.go
+++ b/ignite/cmd/account.go
@@ -60,7 +60,7 @@ func getKeyringBackend(cmd *cobra.Command) cosmosaccount.KeyringBackend {
 
 func flagSetAccountPrefixes() *flag.FlagSet {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
-	fs.String(flagAddressPrefix, "cosmos", "Account address prefix")
+	fs.String(flagAddressPrefix, cosmosaccount.AccountPrefixCosmos, "Account address prefix")
 	return fs
 }
 

--- a/ignite/cmd/network_chain_join.go
+++ b/ignite/cmd/network_chain_join.go
@@ -32,12 +32,14 @@ func NewNetworkChainJoin() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE:  networkChainJoinHandler,
 	}
+
 	c.Flags().String(flagGentx, "", "Path to a gentx json file")
 	c.Flags().String(flagAmount, "", "Amount of coins for account request")
 	c.Flags().AddFlagSet(flagNetworkFrom())
 	c.Flags().AddFlagSet(flagSetHome())
 	c.Flags().AddFlagSet(flagSetKeyringBackend())
 	c.Flags().AddFlagSet(flagSetYes())
+
 	return c
 }
 

--- a/ignite/cmd/network_chain_show_accounts.go
+++ b/ignite/cmd/network_chain_show_accounts.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/icons"
+	"github.com/ignite-hq/cli/ignite/pkg/cosmosutil"
 )
 
 var (
@@ -22,12 +23,16 @@ func newNetworkChainShowAccounts() *cobra.Command {
 		RunE:  networkChainShowAccountsHandler,
 	}
 
+	c.Flags().AddFlagSet(flagSetAccountPrefixes())
+
 	return c
 }
 
 func networkChainShowAccountsHandler(cmd *cobra.Command, args []string) error {
 	session := cliui.New()
 	defer session.Cleanup()
+
+	addressPrefix := getAddressPrefix(cmd)
 
 	nb, launchID, err := networkChainLaunch(cmd, args, session)
 	if err != nil {
@@ -53,12 +58,22 @@ func networkChainShowAccountsHandler(cmd *cobra.Command, args []string) error {
 
 	genesisAccEntries := make([][]string, 0)
 	for _, acc := range genesisAccs {
-		genesisAccEntries = append(genesisAccEntries, []string{acc.Address, acc.Coins})
+		address, err := cosmosutil.ChangeAddressPrefix(acc.Address, addressPrefix)
+		if err != nil {
+			return err
+		}
+
+		genesisAccEntries = append(genesisAccEntries, []string{address, acc.Coins})
 	}
 	genesisVestingAccEntries := make([][]string, 0)
 	for _, acc := range vestingAccs {
+		address, err := cosmosutil.ChangeAddressPrefix(acc.Address, addressPrefix)
+		if err != nil {
+			return err
+		}
+
 		genesisVestingAccEntries = append(genesisVestingAccEntries, []string{
-			acc.Address,
+			address,
 			acc.TotalBalance,
 			acc.Vesting,
 			strconv.FormatInt(acc.EndTime, 10),

--- a/ignite/cmd/network_chain_show_validators.go
+++ b/ignite/cmd/network_chain_show_validators.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
 	"github.com/ignite-hq/cli/ignite/pkg/cliui/icons"
+	"github.com/ignite-hq/cli/ignite/pkg/cosmosutil"
 	"github.com/ignite-hq/cli/ignite/services/network"
 )
 
@@ -19,12 +20,17 @@ func newNetworkChainShowValidators() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE:  networkChainShowValidatorsHandler,
 	}
+
+	c.Flags().AddFlagSet(flagSetAccountPrefixes())
+
 	return c
 }
 
 func networkChainShowValidatorsHandler(cmd *cobra.Command, args []string) error {
 	session := cliui.New()
 	defer session.Cleanup()
+
+	addressPrefix := getAddressPrefix(cmd)
 
 	nb, launchID, err := networkChainLaunch(cmd, args, session)
 	if err != nil {
@@ -45,8 +51,14 @@ func networkChainShowValidatorsHandler(cmd *cobra.Command, args []string) error 
 		if err != nil {
 			return err
 		}
+
+		address, err := cosmosutil.ChangeAddressPrefix(acc.Address, addressPrefix)
+		if err != nil {
+			return err
+		}
+
 		validatorEntries = append(validatorEntries, []string{
-			acc.Address,
+			address,
 			acc.SelfDelegation.String(),
 			peer,
 		})

--- a/ignite/cmd/network_request_list.go
+++ b/ignite/cmd/network_request_list.go
@@ -7,6 +7,7 @@ import (
 	launchtypes "github.com/tendermint/spn/x/launch/types"
 
 	"github.com/ignite-hq/cli/ignite/pkg/cliui"
+	"github.com/ignite-hq/cli/ignite/pkg/cosmosutil"
 	"github.com/ignite-hq/cli/ignite/services/network"
 	"github.com/ignite-hq/cli/ignite/services/network/networktypes"
 )
@@ -22,6 +23,9 @@ func NewNetworkRequestList() *cobra.Command {
 		RunE:  networkRequestListHandler,
 		Args:  cobra.ExactArgs(1),
 	}
+
+	c.Flags().AddFlagSet(flagSetAccountPrefixes())
+
 	return c
 }
 
@@ -33,6 +37,8 @@ func networkRequestListHandler(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	addressPrefix := getAddressPrefix(cmd)
 
 	// parse launch ID
 	launchID, err := network.ParseID(args[0])
@@ -52,11 +58,15 @@ func networkRequestListHandler(cmd *cobra.Command, args []string) error {
 
 	session.StopSpinner()
 
-	return renderRequestSummaries(requests, session)
+	return renderRequestSummaries(requests, session, addressPrefix)
 }
 
 // renderRequestSummaries writes into the provided out, the list of summarized requests
-func renderRequestSummaries(requests []networktypes.Request, session cliui.Session) error {
+func renderRequestSummaries(
+	requests []networktypes.Request,
+	session cliui.Session,
+	addressPrefix string,
+) error {
 	requestEntries := make([][]string, 0)
 	for _, request := range requests {
 		var (
@@ -67,8 +77,17 @@ func renderRequestSummaries(requests []networktypes.Request, session cliui.Sessi
 		switch req := request.Content.Content.(type) {
 		case *launchtypes.RequestContent_GenesisAccount:
 			requestType = "Add Genesis Account"
-			content = fmt.Sprintf("%s, %s",
+
+			address, err := cosmosutil.ChangeAddressPrefix(
 				req.GenesisAccount.Address,
+				addressPrefix,
+			)
+			if err != nil {
+				return err
+			}
+
+			content = fmt.Sprintf("%s, %s",
+				address,
 				req.GenesisAccount.Coins.String())
 		case *launchtypes.RequestContent_GenesisValidator:
 			requestType = "Add Genesis Validator"
@@ -97,10 +116,28 @@ func renderRequestSummaries(requests []networktypes.Request, session cliui.Sessi
 			)
 		case *launchtypes.RequestContent_ValidatorRemoval:
 			requestType = "Remove Validator"
-			content = req.ValidatorRemoval.ValAddress
+
+			address, err := cosmosutil.ChangeAddressPrefix(
+				req.ValidatorRemoval.ValAddress,
+				addressPrefix,
+			)
+			if err != nil {
+				return err
+			}
+
+			content = address
 		case *launchtypes.RequestContent_AccountRemoval:
 			requestType = "Remove Account"
-			content = req.AccountRemoval.Address
+
+			address, err := cosmosutil.ChangeAddressPrefix(
+				req.AccountRemoval.Address,
+				addressPrefix,
+			)
+			if err != nil {
+				return err
+			}
+
+			content = address
 		}
 
 		requestEntries = append(requestEntries, []string{

--- a/ignite/cmd/scaffold_chain.go
+++ b/ignite/cmd/scaffold_chain.go
@@ -25,8 +25,8 @@ func NewScaffoldChain() *cobra.Command {
 	}
 
 	flagSetClearCache(c)
+	c.Flags().AddFlagSet(flagSetAccountPrefixes())
 	c.Flags().StringP(flagPath, "p", ".", "path to scaffold the chain")
-	c.Flags().String(flagAddressPrefix, "cosmos", "Address prefix")
 	c.Flags().Bool(flagNoDefaultModule, false, "Prevent scaffolding a default module in the app")
 
 	return c
@@ -38,9 +38,9 @@ func scaffoldChainHandler(cmd *cobra.Command, args []string) error {
 
 	var (
 		name               = args[0]
-		addressPrefix, _   = cmd.Flags().GetString(flagAddressPrefix)
-		noDefaultModule, _ = cmd.Flags().GetBool(flagNoDefaultModule)
+		addressPrefix      = getAddressPrefix(cmd)
 		appPath            = flagGetPath(cmd)
+		noDefaultModule, _ = cmd.Flags().GetBool(flagNoDefaultModule)
 	)
 
 	cacheStorage, err := newCache(cmd)


### PR DESCRIPTION
close #2219

## Description

All addresses use `spn` as prefix. This PR adds an `address-prefix` flag for `chain show accounts`, `chain show validators`, and `request list`.