### PR TITLE
fix(network/request): fix request simulation

### DIFF
--- a/ignite/cmd/network_request_verify.go
+++ b/ignite/cmd/network_request_verify.go
@@ -112,22 +112,10 @@ func verifyRequest(
 		return err
 	}
 
-	rewardsInfo, lastBlockHeight, unboundingTime, err := n.RewardsInfo(
-		ctx,
-		launchID,
-		chainLaunch.ConsumerRevisionHeight,
-	)
-	if err != nil {
-		return err
-	}
-
 	return c.SimulateRequests(
 		ctx,
 		cacheStorage,
 		genesisInformation,
 		requests,
-		rewardsInfo,
-		lastBlockHeight,
-		unboundingTime,
 	)
 }

--- a/ignite/services/network/networkchain/simulate.go
+++ b/ignite/services/network/networkchain/simulate.go
@@ -30,9 +30,6 @@ func (c Chain) SimulateRequests(
 	cacheStorage cache.Storage,
 	gi networktypes.GenesisInformation,
 	reqs []networktypes.Request,
-	rewardsInfo networktypes.Reward,
-	lastBlockHeight,
-	unbondingTime int64,
 ) (err error) {
 	c.ev.Send(events.New(events.StatusOngoing, "Verifying requests format"))
 	for _, req := range reqs {
@@ -54,10 +51,10 @@ func (c Chain) SimulateRequests(
 		ctx,
 		cacheStorage,
 		gi,
-		rewardsInfo,
+		networktypes.Reward{RevisionHeight: 1},
 		networktypes.SPNChainID,
-		lastBlockHeight,
-		unbondingTime,
+		1,
+		2,
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Headline

The requests cannot be approved or rejected because the rewards info gets the block height zero, and it's invalid in the genesis when we try to simulate the requests.