### PR TITLE
docs: update the scaffold chain inline docs

### DIFF
--- a/ignite/cmd/cmd.go
+++ b/ignite/cmd/cmd.go
@@ -141,7 +141,7 @@ func flagGetProto3rdParty(cmd *cobra.Command) bool {
 }
 
 func flagSetClearCache(cmd *cobra.Command) {
-	cmd.PersistentFlags().Bool(flagClearCache, false, "clears the cache")
+	cmd.PersistentFlags().Bool(flagClearCache, false, "Clear the build cache (advanced)")
 }
 
 func flagGetClearCache(cmd *cobra.Command) bool {

--- a/ignite/cmd/scaffold_chain.go
+++ b/ignite/cmd/scaffold_chain.go
@@ -17,17 +17,40 @@ const (
 // NewScaffoldChain creates new command to scaffold a Comos-SDK based blockchain.
 func NewScaffoldChain() *cobra.Command {
 	c := &cobra.Command{
-		Use:   "chain [github.com/org/repo]",
+		Use:   "chain [name]",
 		Short: "Fully-featured Cosmos SDK blockchain",
-		Long:  "Scaffold a new Cosmos SDK blockchain with a default directory structure",
-		Args:  cobra.ExactArgs(1),
-		RunE:  scaffoldChainHandler,
+		Long: `Create a new application-specific Cosmos SDK blockchain.
+
+For example, the following command will create a blockchain called "hello" in the "hello/" directory:
+
+  ignite scaffold chain hello
+
+A project name can be a simple name or a URL. The name will be used as the Go module path for the project. Examples of project names:
+
+  ignite scaffold chain foo
+  ignite scaffold chain foo/bar
+  ignite scaffold chain example.org/foo
+  ignite scaffold chain github.com/username/foo
+		
+A new directory with source code files will be created in the current directory. To use a different path use the "--path" flag.
+
+Most of the logic of your blockchain is written in custom modules. Each module effectively encapsulates an independent piece of functionality. Following the Cosmos SDK convention, custom modules are stored inside the "x/" directory. By default, Ignite creates a module with a name that matches the name of the project. To create a blockchain without a default module use the "--no-module" flag.
+
+Account addresses on Cosmos SDK-based blockchains have string prefixes. For example, the Cosmos Hub blockchain uses the default "cosmos" prefix, so that addresses look like this: "cosmos12fjzdtqfrrve7zyg9sv8j25azw2ua6tvu07ypf". To use a custom address prefix use the "--address-prefix" flag. For example:
+
+  ignite scaffold chain foo --address-prefix bar
+
+By default when compiling a blockchain's source code Ignite creates a cache to speed up the build process. To clear the cache when building a blockchain use the "--clear-cache" flag. It is very unlikely you will ever need to use this flag.
+
+The blockchain is using the Cosmos SDK modular blockchain framework. Learn more about Cosmos SDK on https://docs.cosmos.network`,
+		Args: cobra.ExactArgs(1),
+		RunE: scaffoldChainHandler,
 	}
 
 	flagSetClearCache(c)
-	c.Flags().StringP(flagPath, "p", ".", "path to scaffold the chain")
+	c.Flags().StringP(flagPath, "p", ".", "Path where a project will be created")
 	c.Flags().String(flagAddressPrefix, "cosmos", "Address prefix")
-	c.Flags().Bool(flagNoDefaultModule, false, "Prevent scaffolding a default module in the app")
+	c.Flags().Bool(flagNoDefaultModule, false, "Create a project without a default module")
 
 	return c
 }

--- a/ignite/cmd/scaffold_chain.go
+++ b/ignite/cmd/scaffold_chain.go
@@ -34,7 +34,7 @@ A project name can be a simple name or a URL. The name will be used as the Go mo
 		
 A new directory with source code files will be created in the current directory. To use a different path use the "--path" flag.
 
-Most of the logic of your blockchain is written in custom modules. Each module effectively encapsulates an independent piece of functionality. Following the Cosmos SDK convention, custom modules are stored inside the "x/" directory. By default, Ignite creates a module with a name that matches the name of the project. To create a blockchain without a default module use the "--no-module" flag.
+Most of the logic of your blockchain is written in custom modules. Each module effectively encapsulates an independent piece of functionality. Following the Cosmos SDK convention, custom modules are stored inside the "x/" directory. By default, Ignite creates a module with a name that matches the name of the project. To create a blockchain without a default module use the "--no-module" flag. Additional modules can be added after a project is created with "ignite scaffold module" command.
 
 Account addresses on Cosmos SDK-based blockchains have string prefixes. For example, the Cosmos Hub blockchain uses the default "cosmos" prefix, so that addresses look like this: "cosmos12fjzdtqfrrve7zyg9sv8j25azw2ua6tvu07ypf". To use a custom address prefix use the "--address-prefix" flag. For example:
 
@@ -48,7 +48,7 @@ The blockchain is using the Cosmos SDK modular blockchain framework. Learn more 
 	}
 
 	flagSetClearCache(c)
-	c.Flags().StringP(flagPath, "p", ".", "Path where a project will be created")
+	c.Flags().StringP(flagPath, "p", ".", "Create a project in a specific path")
 	c.Flags().String(flagAddressPrefix, "cosmos", "Address prefix")
 	c.Flags().Bool(flagNoDefaultModule, false, "Create a project without a default module")
 


### PR DESCRIPTION
I propose we move the docs that are highly relevant to specific commands into the CLI to make it easier to update and use.

<img width="752" alt="Screen Shot 2022-06-05 at 11 45 34" src="https://user-images.githubusercontent.com/332151/172059195-da6f4af0-bad0-4f2e-8aaa-c78ffa5ab8d9.png">
